### PR TITLE
V2.0.2 bug fixes

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -8,7 +8,17 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 Further plan visualization improvements.
 
+Find all references support for _type_.
+
 Auto-completion for constant/object names.
+
+## [2.0.3] - 2017-12-01
+
+Fixed the 'there is no corresponding domain/problem open in the editor' as well as stale PDDL file content while launching the planner.
+
+Planner executable working directory is set to the folder in which the domain and problem files are located.
+
+Entered planner or parser executable/service location is trimmed for whitespace.
 
 ## [2.0.2] - 2017-11-23
 
@@ -60,7 +70,8 @@ Simplified snippets and added tabstops/placeholders to them, so they are easy to
 - PDDL Snippets for `domain`, `problem`, `action` and `durative-action`.
 - Syntax highlighting for commonly used PDDL features
 
-[Unreleased]: https://github.com/jan-dolejsi/vscode-pddl/compare/v2.0.2...HEAD
+[Unreleased]: https://github.com/jan-dolejsi/vscode-pddl/compare/v2.0.3...HEAD
+[2.0.3]:https://github.com/jan-dolejsi/vscode-pddl/compare/v2.0.2...v2.0.3
 [2.0.2]:https://github.com/jan-dolejsi/vscode-pddl/compare/v2.0.1...v2.0.2
 [2.0.1]:https://github.com/jan-dolejsi/vscode-pddl/compare/v2.0.0...v2.0.1
 [2.0.0]:https://github.com/jan-dolejsi/vscode-pddl/compare/v1.0.2...v2.0.0

--- a/client/README.md
+++ b/client/README.md
@@ -86,6 +86,14 @@ See unfixed issues and submit new ones [here][github pddl issues].
 
 ## Release Notes
 
+### 2.0.3
+
+Fixed the 'there is no corresponding domain/problem open in the editor' as well as stale PDDL file content while launching the planner.
+
+Planner executable working directory is set to the folder in which the domain and problem files are located.
+
+Entered planner or parser executable/service location is trimmed for whitespace.
+
 ### 2.0.2
 
 Plan visualization that features color-coding of actions and swim-lanes for objects per types.

--- a/client/package.json
+++ b/client/package.json
@@ -4,7 +4,7 @@
     "description": "Planning Domain Description Language support",
 	"author": "Jan Dolejsi",
 	"license": "MIT",
-	"version": "2.0.2",
+	"version": "2.0.3",
 	"publisher": "jan-dolejsi",
 	"engines": {
 		"vscode": "^1.16.0"

--- a/client/publish.cmd
+++ b/client/publish.cmd
@@ -5,7 +5,7 @@ pause
 call vsce package
 :: https://code.visualstudio.com/docs/editor/extension-gallery#_install-from-a-vsix
 echo test extension 
-call code --install-extension pddl-2.0.2.vsix
+call code --install-extension pddl-2.0.3.vsix
 pause
-call vsce publish --packagePath pddl-2.0.2.vsix 
+call vsce publish --packagePath pddl-2.0.3.vsix 
 ::major minor patch 

--- a/client/src/PlannerExecutable.ts
+++ b/client/src/PlannerExecutable.ts
@@ -22,7 +22,7 @@ export class PlannerExecutable extends Planner {
     // this property stores the reference to the planner child process, while planning is in progress
     child: process.ChildProcess;
 
-    constructor(plannerPath: string, plannerOptions: string, public plannerSyntax: string) {
+    constructor(plannerPath: string, plannerOptions: string, public plannerSyntax: string, public workingDirectory: string) {
         super(plannerPath, plannerOptions);
     }
 
@@ -41,7 +41,9 @@ export class PlannerExecutable extends Planner {
         let thisPlanner = this;
         super.planningProcessKilled = false;
 
-        this.child = process.exec(command, (error, stdout, stderr) => {
+        this.child = process.exec(command, 
+            { cwd: this.workingDirectory },
+            (error, stdout, stderr) => {
             planParser.onPlanFinished();
 
             if (error && !thisPlanner.child.killed && !this.planningProcessKilled) {

--- a/client/src/configuration.ts
+++ b/client/src/configuration.ts
@@ -99,6 +99,8 @@ export class PddlConfiguration {
         });
 
         if (newParserPath) {
+            newParserPath = newParserPath.trim();
+            
             // todo: validate that this parser actually works by sending a dummy request to it
 
             let newParserScope = await this.askConfigurationScope();
@@ -165,6 +167,9 @@ export class PddlConfiguration {
         });
 
         if (newPlannerPath) {
+
+            newPlannerPath = newPlannerPath.trim();
+            
             // todo: validate that this planner actually works by sending a dummy request to it
 
             let newPlannerScope = await this.askConfigurationScope();

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -105,18 +105,21 @@ function toRange(pddlRange: PddlRange): Range {
 
 function subscribeToWorkspace(pddlWorkspace: PddlWorkspace, context: ExtensionContext): void {
 	workspace.textDocuments
-		.filter(textDoc => textDoc.languageId == 'pddl')
+		.filter(textDoc => isPddl(textDoc))
 		.forEach(textDoc => {
 			pddlWorkspace.upsertFile(textDoc.uri.toString(), textDoc.version, textDoc.getText());
 		});
 
 	context.subscriptions.push(workspace.onDidOpenTextDocument(textDoc => { if(isPddl(textDoc)) pddlWorkspace.upsertFile(textDoc.uri.toString(), textDoc.version, textDoc.getText())}));
-	context.subscriptions.push(workspace.onDidChangeTextDocument(docEvent => { if(isPddl(docEvent.document)) pddlWorkspace.upsertFile(docEvent.document.uri.toString(), docEvent.document.version, docEvent.document.getText())}));
+	context.subscriptions.push(workspace.onDidChangeTextDocument(docEvent => { 
+		if(isPddl(docEvent.document)) 
+			pddlWorkspace.upsertFile(docEvent.document.uri.toString(), docEvent.document.version, docEvent.document.getText())
+		}));
 	context.subscriptions.push(workspace.onDidCloseTextDocument(docEvent => { if(isPddl(docEvent)) pddlWorkspace.removeFile(docEvent.uri.toString())}));
 }
 
 function isPddl(doc: TextDocument): boolean {
-	return doc.languageId.toLowerCase() == PDDL;
+	return doc.languageId.toLowerCase() == PDDL.toLowerCase();
 }
 
 function uninstallLegacyExtension(pddlConfiguration: PddlConfiguration) {

--- a/client/src/planning.ts
+++ b/client/src/planning.ts
@@ -112,7 +112,7 @@ export class Planning implements PlanningHandler {
 
         let planParser = new PddlPlanParser(domainFileInfo, problemFileInfo, this.plannerConfiguration.getEpsilonTimeStep(), plans => this.visualizePlans(plans));
 
-        this.planner = await this.createPlanner();
+        this.planner = await this.createPlanner(Planning.getFolderPath(activeDocument.fileName));
         if (!this.planner) return false;
 
         this.planningProcessKilled = false;
@@ -129,7 +129,7 @@ export class Planning implements PlanningHandler {
     /**
      * Creates the right planner wrapper according to the current configuration.
      */
-    async createPlanner(): Promise<Planner> {
+    async createPlanner(workingDirectory: string): Promise<Planner> {
         let plannerPath = await this.plannerConfiguration.getPlannerPath();
         if (!plannerPath) return null;
 
@@ -143,7 +143,7 @@ export class Planning implements PlanningHandler {
             let plannerSyntax = await this.plannerConfiguration.getPlannerSyntax();
             if (plannerSyntax == null) return null;
 
-            return new PlannerExecutable(plannerPath, plannerOptions, plannerSyntax);
+            return new PlannerExecutable(plannerPath, plannerOptions, plannerSyntax, workingDirectory);
         }
     }
 

--- a/common/src/parser.ts
+++ b/common/src/parser.ts
@@ -97,23 +97,24 @@ export class Parser {
     }
 
     parseInheritance(declarationText: string): DirectionalGraph {
-        let pattern = /((\w[\w-]*\s*)+-\s*\w[\w-]*|\w[\w-]*)/g;
 
         // the inheritance graph is captured as a two dimensional array, where the first index is the types themselves, the second is the parent type they inherit from (PDDL supports multiple inheritance)
         let inheritance = new DirectionalGraph();
 
         if (!declarationText) return inheritance; 
 
-        // for some reason in cases without type inheritance, the regexp above is very slow
-        if(!declarationText.includes('-') && !declarationText.match(/\bobject\b/i)){
+        // if there are root types that do not inherit from 'object', add the 'object' inheritance.
+        // it will make the following regex work
+        if(!declarationText.match(/-\s+\w[\w-]*\s*$/)){
             declarationText += ' - object';
         }
 
+        let pattern = /(\w[\w-]*\s+)+-\s+\w[\w-]*/g;
         let match;
         while (match = pattern.exec(declarationText)) {
             // is this a group with inheritance?
-            if (match[1].indexOf(' -')) {
-                let fragments = match[1].split('-');
+            if (match[0].indexOf(' -')) {
+                let fragments = match[0].split('-');
                 let parent = fragments[1] ? fragments[1].trim() : null;
                 let children = fragments[0].trim().split(/\s+/g, );
 

--- a/common/test/ParserTest.ts
+++ b/common/test/ParserTest.ts
@@ -68,7 +68,7 @@ describe('Parser', () => {
 
             assert.ok(graph.getEdgesFrom(child).includes(parent), 'child should have parent');
             assert.ok(graph.getEdgesFrom(parent).length == 0, 'parent should not have parent');
-            assert.ok(graph.getEdgesFrom(orphan).length == 0, 'orphan should not have parent');
+            assert.ok(graph.getEdgesFrom(orphan).length == 1, 'orphan should not have "object" parent');
         });
 
         it('should parse 2 parent-child declarations', () => {

--- a/todo.md
+++ b/todo.md
@@ -7,3 +7,6 @@ https://github.com/primaryobjects/strips
 https://github.com/hfoffani/pddl-lib
 
 And btw, the online editor (http://editor.planning.domains/) uses the Ace editor (https://ace.c9.io/)
+
+Google line chart configured as a sparkline: 
+https://jsfiddle.net/k7sem25f/


### PR DESCRIPTION
Fixed the 'there is no corresponding domain/problem open in the editor' as well as stale PDDL file content while launching the planner.

Planner executable working directory is set to the folder in which the domain and problem files are located.

Entered planner or parser executable/service location is trimmed for whitespace.