### PR TITLE
Fix 2 15 3

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -1,5 +1,13 @@
 # PDDL support - What's new?
 
+## Work in progress
+
+- fixed generated problem file/tab name for the pre-parse preview
+- demoted Jinja2 errors to make it possible to edit the files
+- Configuration selector menu shows current value
+- Introduced configuration to disable the model hierarchy decorator (for perf reasons)
+- added PDDL3.1 `undefined` to syntax highlighting
+
 ## [2.15.2] Predicate and function references
 
 - predicate/function references in hover and decorations (image needed)

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [2.15.3] Bug fixes
 
 - Fixed generated problem file/tab name for the pre-parse preview
-- Demoted Jinja2 errors to make it possible to edit the files
+- Support for spaces in problem template pre-process command-line
+- Demoted Jinja2 errors to parsing problems make it possible to edit the files
 - Configuration selector menu shows current value
 - Introduced configuration to disable the model hierarchy decorator (for perf reasons)
 - Added PDDL3.1 `undefined` to syntax highlighting

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -1,12 +1,14 @@
 # PDDL support - What's new?
 
-## Work in progress
+## [2.15.3] Bug fixes
 
-- fixed generated problem file/tab name for the pre-parse preview
-- demoted Jinja2 errors to make it possible to edit the files
+- Fixed generated problem file/tab name for the pre-parse preview
+- Demoted Jinja2 errors to make it possible to edit the files
 - Configuration selector menu shows current value
 - Introduced configuration to disable the model hierarchy decorator (for perf reasons)
-- added PDDL3.1 `undefined` to syntax highlighting
+- Added PDDL3.1 `undefined` to syntax highlighting
+- To address the [Issue #49](https://github.com/jan-dolejsi/vscode-pddl/issues/49) confusion why the search debugger is not displaying anything, when a planning service is called, the extension will now show a warning message that the search debugger config switch is being ignored.
+- Removed tips that were not effective at teaching how to use the more hidden features [Issue #47](https://github.com/jan-dolejsi/vscode-pddl/issues/49) as suggested and fixed by [@boramalper](https://github.com/jan-dolejsi/vscode-pddl/pull/48)
 
 ## [2.15.2] Predicate and function references
 
@@ -873,7 +875,8 @@ Note for open source contributors: all notable changes to the "pddl" extension w
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
-[Unreleased]: https://github.com/jan-dolejsi/vscode-pddl/compare/v2.15.2...HEAD
+[Unreleased]: https://github.com/jan-dolejsi/vscode-pddl/compare/v2.15.3...HEAD
+[2.15.3]:https://github.com/jan-dolejsi/vscode-pddl/compare/v2.15.2...v2.15.3
 [2.15.2]:https://github.com/jan-dolejsi/vscode-pddl/compare/v2.15.1...v2.15.2
 [2.15.1]:https://github.com/jan-dolejsi/vscode-pddl/compare/v2.15.0...v2.15.1
 [2.15.0]:https://github.com/jan-dolejsi/vscode-pddl/compare/v2.14.4...v2.15.0

--- a/client/package.json
+++ b/client/package.json
@@ -755,6 +755,11 @@
           "default": false,
           "description": "Enable PDDL formatter (default is 'false'). Warning: this is an experimental feature - work in progress."
         },
+        "pddl.modelHierarchy": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable the PDDL model hierarchy decorator (predicate and function usage)"
+        },
         "pddlSearchDebugger.defaultPort": {
           "type": "integer",
           "description": "Search debugger static port. If not specified (or set to zero, the port is randomized for security reasons).",

--- a/client/package.json
+++ b/client/package.json
@@ -4,7 +4,7 @@
   "description": "Planning Domain Description Language support",
   "author": "Jan Dolejsi",
   "license": "MIT",
-  "version": "2.15.2",
+  "version": "2.15.3",
   "publisher": "jan-dolejsi",
   "engines": {
     "vscode": "^1.40.0",

--- a/client/publish.cmd
+++ b/client/publish.cmd
@@ -13,7 +13,7 @@ call vsce package
 :: https://code.visualstudio.com/docs/editor/extension-gallery#_install-from-a-vsix
 echo Installing the extension locally...
 ::major minor patch
-call code --install-extension pddl-2.15.2.vsix
+call code --install-extension pddl-2.15.3.vsix
 echo Test extension before you continue
 pause
-call vsce publish --packagePath pddl-2.15.2.vsix
+call vsce publish --packagePath pddl-2.15.3.vsix

--- a/client/scripts/transform_jinja2.py
+++ b/client/scripts/transform_jinja2.py
@@ -18,6 +18,18 @@ except ImportError:
 # read the template from the standard input
 template_text = "".join(sys.stdin.readlines())
 
+def tif_filter(time: float, value: float, *function_name) -> str:
+    assignment = "(= ({}) {})".format(' '.join(function_name), value)
+    return "(at {} {})".format(time, assignment) if time > 0\
+        else assignment
+
+def map_filter(value: any, attribute_name: str, default=None) -> any:
+    """ map filter to translate value object to its selected attribute """
+    if hasattr(value, attribute_name):
+        return value[attribute_name]
+    else:
+        return default
+
 def main(args):
     """ Transforms the problem file streamed in through the standard input using JSON the data file passed via command-line argument. """
     if len(args) < 1:
@@ -30,6 +42,8 @@ def main(args):
         input_data = json.load(fp)
 
     template = Template(template_text)
+    template.environment.filters['tif'] = tif_filter
+    template.environment.filters['mapattr'] = map_filter
 
     rendered = template.render(data=input_data)
 

--- a/client/src/configuration.ts
+++ b/client/src/configuration.ts
@@ -444,7 +444,7 @@ export class PddlConfiguration {
         }
 
         let itemSelected = await vscode.window.showQuickPick(items, {
-            placeHolder: configurationElement["description"]
+            placeHolder: configurationElement["description"] + ` (current value: ${currentValue})`
         });
 
         if (itemSelected === undefined) { return; }

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -188,9 +188,11 @@ function activateWithTelemetry(_operationId: string, context: ExtensionContext) 
 
 	let renameProvider = languages.registerRenameProvider(PDDL, new SymbolRenameProvider(codePddlWorkspace));
 	
-	let modelHierarchyProvider = new ModelHierarchyProvider(context, codePddlWorkspace);
-	context.subscriptions.push(languages.registerHoverProvider(PDDL, modelHierarchyProvider));
-
+	if (workspace.getConfiguration("pddl").get<boolean>("modelHierarchy")) {
+		let modelHierarchyProvider = new ModelHierarchyProvider(context, codePddlWorkspace);
+		context.subscriptions.push(languages.registerHoverProvider(PDDL, modelHierarchyProvider));
+	}
+	
 	let symbolInfoProvider = new SymbolInfoProvider(codePddlWorkspace);
 
 	let documentSymbolProvider = languages.registerDocumentSymbolProvider(PDDL, symbolInfoProvider);
@@ -238,6 +240,8 @@ function activateWithTelemetry(_operationId: string, context: ExtensionContext) 
 	let configureCommand = instrumentOperationAsVsCodeCommand(PDDL_CONFIGURE_COMMAND, (configurationName: string) => {
 		pddlConfiguration.askConfiguration(configurationName).catch(showError);
 	});
+
+	console.log('PDDL Extension initialized.');
 
 	// Push the disposables to the context's subscriptions so that the
 	// client can be deactivated on extension deactivation

--- a/client/src/planning/PlannerExecutable.ts
+++ b/client/src/planning/PlannerExecutable.ts
@@ -38,7 +38,7 @@ export class PlannerExecutable extends Planner {
             .replace('$(domain)', Util.q(domainFilePath))
             .replace('$(problem)', Util.q(problemFilePath));
 
-        command += ' ' + parent.providePlannerOptions({ domain: domainFileInfo, problem: problemFileInfo });
+        command += ' ' + parent.providePlannerOptions({ domain: domainFileInfo, problem: problemFileInfo }).join(' ');
 
         parent.handleOutput(command + '\n');
 

--- a/client/src/planning/PlannerResponseHandler.ts
+++ b/client/src/planning/PlannerResponseHandler.ts
@@ -5,9 +5,16 @@
 'use strict';
 
 import { Plan } from "../../../common/src/Plan";
-import { PlannerOptionsProvider } from "./PlannerOptionsProvider";
+import { PlanningRequestContext } from "./PlannerOptionsProvider";
 
-export interface PlannerResponseHandler extends PlannerOptionsProvider {
+export interface PlannerResponseHandler {
     handleOutput(outputText: string): void;
     handlePlan(plan: Plan): void;
+
+    /**
+     * Callback to provide planner config options to pass to the planner.
+     * This aggregates all the options from all the registered providers.
+     * @param request planning request context
+     */
+    providePlannerOptions(request: PlanningRequestContext): string[];
 }

--- a/client/src/planning/PlannerService.ts
+++ b/client/src/planning/PlannerService.ts
@@ -13,6 +13,7 @@ import { DomainInfo } from '../../../common/src/DomainInfo';
 import { PddlPlanParser } from '../../../common/src/PddlPlanParser';
 import { PlanStep } from '../../../common/src/PlanStep';
 import { Authentication } from '../../../common/src/Authentication';
+import { window } from 'vscode';
 
 export abstract class PlannerService extends Planner {
 
@@ -35,6 +36,10 @@ export abstract class PlannerService extends Planner {
             requestHeader = {
                 "Authorization": "Bearer " + this.authentication.getSToken()!
             };
+        }
+
+        if (parent.providePlannerOptions({ domain: domainFileInfo, problem: problemFileInfo }).length > 0) {
+            window.showWarningMessage("Search Debugger is not supported by planning services. Only planner executable may support it.");
         }
 
         let requestBody = await this.createRequestBody(domainFileInfo, problemFileInfo);

--- a/client/src/planning/PlannerUserOptionsSelector.ts
+++ b/client/src/planning/PlannerUserOptionsSelector.ts
@@ -6,7 +6,7 @@ import * as vscode from 'vscode';
 
 export class PlannerUserOptionsSelector {
 
-    private NO_OPTIONS: OptionsQuickPickItem = { label: 'No options.', options: '', description: '' };
+    private NO_OPTIONS: OptionsQuickPickItem = { label: 'No options (use defaults)', options: '', description: '' };
     private optionsHistory: OptionsQuickPickItem[] = [ this.NO_OPTIONS, { label: 'Specify options...', newValue: true, options: '', description: '' }];
 
     async getPlannerOptions(): Promise<string | undefined> {

--- a/client/src/planning/planning.ts
+++ b/client/src/planning/planning.ts
@@ -136,8 +136,8 @@ export class Planning implements PlannerResponseHandler {
         this.optionProviders.push(optionsProvider);
     }
 
-    providePlannerOptions(context: PlanningRequestContext): string {
-        return this.optionProviders.map(provider => provider.providePlannerOptions(context)).join(' ');
+    providePlannerOptions(context: PlanningRequestContext): string[] {
+        return this.optionProviders.map(provider => provider.providePlannerOptions(context));
     }
 
     /**

--- a/client/src/ptest/GeneratedDocumentContentProvider.ts
+++ b/client/src/ptest/GeneratedDocumentContentProvider.ts
@@ -58,7 +58,7 @@ export class GeneratedDocumentContentProvider implements TextDocumentContentProv
         let problemTemplateWithoutExtension = problemTemplatePath.replace('.pddl', '');
 
         if (test.getLabel()) {
-            problemPath = join(problemTemplateWithoutExtension + ` (${test.getLabel()}).pddl`);
+            problemPath = join(problemTemplateWithoutExtension + ` (${this.sanitizePath(test.getLabel())}).pddl`);
         }
         else {
             problemPath = problemTemplateWithoutExtension + ` (${testIdx}).pddl`;
@@ -71,6 +71,10 @@ export class GeneratedDocumentContentProvider implements TextDocumentContentProv
         return uri;
     }
 
+    sanitizePath(path: string): string {
+        return path.split(/[\\\/]/).join('_');
+    }
+
     async provideTextDocumentContent(uri: Uri, token: CancellationToken): Promise<string> {
         let test = this.uriMap.get(uri.toString());
         if (!test) { return `Document ${uri.toString()} not found in the content provider's map.`; }
@@ -80,12 +84,12 @@ export class GeneratedDocumentContentProvider implements TextDocumentContentProv
         let documentText = problemDocument.getText();
 
         try {
-            let preProcessedProblemText =  await test.getPreProcessor()?.transform(documentText, dirname(test.getManifest().path), this.outputWindow) || "No pre-processor configured.";
+            let preProcessedProblemText =  await test.getPreProcessor()?.transform(documentText, dirname(test.getManifest().path), this.outputWindow) ?? "No pre-processor configured.";
             // force parsing of the generated problem
             this.pddlWorkspace.pddlWorkspace.upsertFile(uri.toString(), PddlLanguage.PDDL, 0, preProcessedProblemText, new SimpleDocumentPositionResolver(preProcessedProblemText), true);
             return preProcessedProblemText;
         } catch (ex) {
-            return `Problem file '${basename(uri.fsPath)}' failed to generate: ${ex.message}`;
+            return `;;Problem file '${basename(uri.fsPath)}' failed to generate: ${ex.message}\n\n` + documentText;
         }
     }
 }

--- a/client/src/symbols/ModelHierarchyProvider.ts
+++ b/client/src/symbols/ModelHierarchyProvider.ts
@@ -200,7 +200,7 @@ export class ModelHierarchyProvider implements HoverProvider {
             }
 
         } else {
-            throw new Error("Method not implemented.");
+            return undefined;
         }
     }
 

--- a/client/src/symbols/SuggestionProvider.ts
+++ b/client/src/symbols/SuggestionProvider.ts
@@ -88,7 +88,7 @@ export class SuggestionProvider implements CodeActionProvider {
     }
 
     private createTest(document: TextDocument, preProcessor: PreProcessor): Test {
-        let test = new Test(preProcessor.toString(), "", "this should not be used",
+        let test = new Test(preProcessor.getLabel(), "", "this should not be used",
             basename(document.uri.fsPath), "", preProcessor, []);
         test.setManifest(new TestsManifest('unused', 'unused', 'unused', document.uri)); // only the uri is needed
         return test;

--- a/client/syntaxes/pddl.tmLanguage.json
+++ b/client/syntaxes/pddl.tmLanguage.json
@@ -120,6 +120,10 @@
 					"match": "\\b(assign|increase|decrease|forall|exists)\\b"
 				},
 				{
+					"name": "keyword.other.undefined",
+					"match": "\\b(undefined)\\b"
+				},
+				{
 					"name": "keyword.other.metric",
 					"match": "\\b(minimize|maximize)\\b"
 				}

--- a/common/src/PreProcessors.ts
+++ b/common/src/PreProcessors.ts
@@ -19,6 +19,7 @@ export abstract class PreProcessor {
     abstract transform(input: string, workingDirectory: string, outputWindow: OutputAdaptor): Promise<string>;
     abstract toString(): string;
     abstract getInputFiles(): string[];
+    abstract getLabel(): string;
 
     protected removeMetaDataLine(text: string) {
         let pattern = /^;;\s*!pre-parsing:/;
@@ -47,13 +48,25 @@ export class CommandPreProcessor extends PreProcessor {
         return [];
     }
 
+    getLabel(): string {
+        return this.command;
+    }
+
+    handleError(error: Error): void {
+        throw new PreProcessingError(error.message, 0, 0);
+    }
+
+    handleErrorAsync(error: Error, reject: (message: any) => void): void {
+        reject(new PreProcessingError(error.message, 0, 0));
+    }
+
     async transform(input: string, workingDirectory: string, outputWindow: OutputAdaptor): Promise<string> {
 
-        let command = this.command + ' ' + this.args.join(' ');
         let that = this;
 
         return new Promise<string>(function (resolve, reject) {
-            let childProcess = process.exec(command,
+            let childProcess = process.execFile(that.command,
+                that.args,
                 {
                     cwd: workingDirectory
                 },
@@ -66,10 +79,8 @@ export class CommandPreProcessor extends PreProcessor {
                     if (error) {
                         outputWindow.appendLine('Failed to transform the problem file.');
                         outputWindow.appendLine(error.message);
-                        outputWindow.show();
-                        reject(error);
+                        that.handleErrorAsync(error, reject);
                         resolve(input);
-                        return;
                     }
                     else {
                         resolve(that.removeMetaDataLine(stdout));
@@ -95,8 +106,33 @@ export class PythonPreProcessor extends CommandPreProcessor {
         return this.args;
     }
 
+    getLabel(): string {
+        return this.args.join(' ');
+    }
+
     static fromJson(_json: any): any {
         throw new Error("For Jinja2 pre-processor, use the constructor instead");
+    }
+
+    private static readonly JINJA2_TEMPLATE_SYNTAX_ERROR_PREFIX = 'jinja2.exceptions.TemplateSyntaxError: ';
+    private static readonly PYTHON_JSON_DECODER = 'json.decoder.JSONDecodeError: ';
+
+    handleErrorAsync(error: Error, reject: (message: any) => void): void {
+        let errorLines = error.message.split('\n');
+        
+        let templateSyntaxError = errorLines.find(row => row.startsWith(PythonPreProcessor.JINJA2_TEMPLATE_SYNTAX_ERROR_PREFIX));
+        if (templateSyntaxError) {
+            reject(new PreProcessingError(templateSyntaxError.substring(PythonPreProcessor.JINJA2_TEMPLATE_SYNTAX_ERROR_PREFIX.length), 0, 0));
+            return;
+        }
+        
+        let pythonJsonError = errorLines.find(row => row.startsWith(PythonPreProcessor.PYTHON_JSON_DECODER));
+        if (pythonJsonError) {
+            reject(new PreProcessingError('JSON Error: ' + pythonJsonError.substring(PythonPreProcessor.PYTHON_JSON_DECODER.length), 0, 0));
+            return;
+        }
+        
+        super.handleErrorAsync(error, reject);
     }
 }
 
@@ -114,6 +150,10 @@ export class Jinja2PreProcessor extends PythonPreProcessor {
 
     getInputFiles(): string[] {
         return [this.dataFileName];
+    }
+
+    getLabel(): string {
+        return this.dataFileName;
     }
 }
 
@@ -137,6 +177,10 @@ export class NunjucksPreProcessor extends PreProcessor {
 
     getInputFiles(): string[] {
         return [this.dataFileName];
+    }
+
+    getLabel(): string {
+        return this.dataFileName;
     }
 
     toString(): string {


### PR DESCRIPTION
## [2.15.3] Bug fixes

- Fixed generated problem file/tab name for the pre-parse preview
- Support for spaces in problem template pre-process command-line
- Demoted Jinja2 errors to parsing problems make it possible to edit the files
- Configuration selector menu shows current value
- Introduced configuration to disable the model hierarchy decorator (for perf reasons)
- Added PDDL3.1 `undefined` to syntax highlighting
- To address the [Issue #49](https://github.com/jan-dolejsi/vscode-pddl/issues/49) confusion why the search debugger is not displaying anything, when a planning service is called, the extension will now show a warning message that the search debugger config switch is being ignored.
- Removed tips that were not effective at teaching how to use the more hidden features [Issue #47](https://github.com/jan-dolejsi/vscode-pddl/issues/49) as suggested and fixed by [@boramalper](https://github.com/jan-dolejsi/vscode-pddl/pull/48)
