### PR TITLE
Typescript 3.7.3

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,33 @@
+name: VSCode Extension CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+    
+    strategy:
+      matrix:
+        node-version: [10.16]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm install
+    - run: npm test
+      working-directory: common
+    - run: npm run compile --if-present
+      working-directory: client
+    - name: Package extension
+      if: success() && github.ref == 'refs/heads/master'
+      run: | 
+        npm install -g vsce
+        vsce package
+      working-directory: client
+      # See https://github.com/keesschollaart81/vscode-home-assistant/blob/master/.github/workflows/github-actions-vscode-extension.yml
+      env:
+        CI: true

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -7,6 +7,7 @@
   - Bulk replaced Typescript `||` with `??` operator where appropriate (i.e. when returning default numeric or more generally non-boolean values).
   - Simplified code by optional chaining using the `.?` Elvis operator.
 - More Typescript strict semantic checking clean-up
+- GitHub Actions used for CI
 
 ## [2.15.3] Bug fixes
 

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 - Planning Domain Session generation email sending is repaired. VS Code changed behavior of the `env.openExternal(Uri)` API and prevented it from opening `mailto:` URLs.
 - Updated to Typescript 3.7.3
-- Bulk replaced Typescript || with ?? operator where appropriate (i.e. when returning default numeric or more generally non-boolean values).
-- Simplified code by using the `.?` Elvis operator.
+  - Bulk replaced Typescript `||` with `??` operator where appropriate (i.e. when returning default numeric or more generally non-boolean values).
+  - Simplified code by optional chaining using the `.?` Elvis operator.
 - More Typescript strict semantic checking clean-up
 
 ## [2.15.3] Bug fixes

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -1,5 +1,13 @@
 # PDDL support - What's new?
 
+## Under development
+
+- Planning Domain Session generation email sending is repaired. VS Code changed behavior of the `env.openExternal(Uri)` API and prevented it from opening `mailto:` URLs.
+- Updated to Typescript 3.7.3
+- Bulk replaced Typescript || with ?? operator where appropriate (i.e. when returning default numeric or more generally non-boolean values).
+- Simplified code by using the `.?` Elvis operator.
+- More Typescript strict semantic checking clean-up
+
 ## [2.15.3] Bug fixes
 
 - Fixed generated problem file/tab name for the pre-parse preview

--- a/client/package.json
+++ b/client/package.json
@@ -890,7 +890,7 @@
     "@types/tmp": "^0.1.0",
     "@types/adm-zip": "^0.4.32",
     "tslint": "^5.20.0",
-    "typescript": "^3.7.2",
+    "typescript": "^3.7.3",
     "vsce": "^1.63.0",
     "vscode-test": "^1.0.0",
     "glob": "^7.1.4",

--- a/client/src/Menu.ts
+++ b/client/src/Menu.ts
@@ -14,7 +14,7 @@ export class Menu {
         let selectedItem = await window.showQuickPick(this.items, this.options, token);
 
         if (selectedItem !== undefined) {
-            await commands.executeCommand(selectedItem.command, ...(selectedItem.args || []));
+            await commands.executeCommand(selectedItem.command, ...(selectedItem.args ?? []));
         }
 
         return selectedItem;

--- a/client/src/completion/AbstractCompletionItemProvider.ts
+++ b/client/src/completion/AbstractCompletionItemProvider.ts
@@ -47,7 +47,7 @@ export class AbstractCompletionItemProvider {
     protected createSnippetCompletionItem(suggestion: Suggestion | null, snippet: string, range: Range | null, _context: CompletionContext, index: number): CompletionItem | null {
         if (suggestion === null) { return null; }
         let suggestionDetail = this.suggestionDetails.get(suggestion.sectionName);
-        let completionItem = new CompletionItem(suggestion.sectionName, (suggestionDetail && suggestionDetail.kind) || CompletionItemKind.Keyword);
+        let completionItem = new CompletionItem(suggestion.sectionName, suggestionDetail?.kind ?? CompletionItemKind.Keyword);
         completionItem.insertText = new SnippetString(snippet);
         
         if (range) { completionItem.range = range; }

--- a/client/src/completion/AutoCompletion.ts
+++ b/client/src/completion/AutoCompletion.ts
@@ -81,7 +81,7 @@ class CompletionCollector {
     createProblemCompletionItems(problemFileInfo: ProblemInfo): void {
         let folder = this.codePddlWorkspace.pddlWorkspace.getFolderOf(problemFileInfo);
         // find domain files in the same folder that match the problem's domain name
-        let domainFiles = folder?.getDomainFilesFor(problemFileInfo) || [];
+        let domainFiles = folder?.getDomainFilesFor(problemFileInfo) ?? [];
 
         if (this.isInInit()) {
             new ProblemInitDelegate(this.completions, this.context).createProblemInitCompletionItems(problemFileInfo, domainFiles);

--- a/client/src/completion/PddlCompletionItemProvider.ts
+++ b/client/src/completion/PddlCompletionItemProvider.ts
@@ -29,15 +29,27 @@ export class PddlCompletionItemProvider implements CompletionItemProvider {
         let fileInfo = await this.codePddlWorkspace?.upsertAndParseFile(document);
 
         if (fileInfo instanceof DomainInfo) {
-            return await (this.domainProvider || (this.domainProvider = new DomainCompletionItemProvider())).provide(document, <DomainInfo>fileInfo, position, context);
+            return await this.getOrCreateDomainCompletionItemProvider().provide(document, <DomainInfo>fileInfo, position, context);
         }
         else if (fileInfo instanceof ProblemInfo) {
-            return await (this.problemProvider || (this.problemProvider = new ProblemCompletionItemProvider())).provide(document, <ProblemInfo>fileInfo, position, context);
+            return await this.getOrCreateProblemCompletionItemProvider().provide(document, <ProblemInfo>fileInfo, position, context);
         }
         else if (fileInfo instanceof UnknownFileInfo || fileInfo === null) {
-            return await (this.unknownProvider || (this.unknownProvider = new UnknownPddlCompletionItemProvider())).provide(document, position, context);
+            return await this.getOrCreateUnknownFileItemProvider().provide(document, position, context);
         } 
 
         return [];
+    }
+
+    private getOrCreateDomainCompletionItemProvider() {
+        return this.domainProvider ?? (this.domainProvider = new DomainCompletionItemProvider());
+    }
+
+    private getOrCreateProblemCompletionItemProvider() {
+        return this.problemProvider ?? (this.problemProvider = new ProblemCompletionItemProvider());
+    }
+
+    private getOrCreateUnknownFileItemProvider() {
+        return this.unknownProvider ?? (this.unknownProvider = new UnknownPddlCompletionItemProvider());
     }
 }

--- a/client/src/debugger/HappeningsExecutor.ts
+++ b/client/src/debugger/HappeningsExecutor.ts
@@ -128,7 +128,7 @@ export class HappeningsExecutor {
     }
 
     createRange(happening: Happening): vscode.Range {
-        let line = happening.lineIndex || 0;
+        let line = happening.lineIndex ?? 0;
         return new vscode.Range(line, 0, line, 100);
     }
 }

--- a/client/src/diagnostics/Diagnostics.ts
+++ b/client/src/diagnostics/Diagnostics.ts
@@ -340,5 +340,5 @@ function toDiagnostics(problems: ParsingProblem[]): Diagnostic[] {
 }
 
 function toDiagnostic(problem: ParsingProblem): Diagnostic {
-    return createDiagnostic(problem.lineIndex || 0, problem.columnIndex, problem.problem, DiagnosticSeverity.Error);
+    return createDiagnostic(problem.lineIndex ?? 0, problem.columnIndex, problem.problem, DiagnosticSeverity.Error);
 }

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -66,6 +66,7 @@ export async function activate(context: ExtensionContext) {
 	}
 	catch (ex) {
 		// sadly, the next line never gets triggered, even if the activateWithTelemetry fails
+		console.error("Error during PDDL extension activation: " + (ex.message ?? ex));
 		window.showErrorMessage("There was an error starting the PDDL extension: " + ex.message);
 	}
 }

--- a/client/src/init/OverviewPage.ts
+++ b/client/src/init/OverviewPage.ts
@@ -101,7 +101,7 @@ export class OverviewPage {
                     await this.helloWorld();
                 }
                 catch (ex) {
-                    window.showErrorMessage(ex.message || ex);
+                    window.showErrorMessage(ex.message ?? ex);
                 }
                 break;
             case 'openNunjucksSample':
@@ -109,7 +109,7 @@ export class OverviewPage {
                     await this.openNunjucksSample();
                 }
                 catch (ex) {
-                    window.showErrorMessage(ex.message || ex);
+                    window.showErrorMessage(ex.message ?? ex);
                 }
                 break;
             case 'clonePddlSamples':

--- a/client/src/modelView/DomainViewPanel.ts
+++ b/client/src/modelView/DomainViewPanel.ts
@@ -42,7 +42,7 @@ export class DomainViewPanel extends BaseViewPanel {
     }
 
     reveal(displayColumn?: ViewColumn): void {
-        this.panel.reveal(displayColumn || ViewColumn.Beside);
+        this.panel.reveal(displayColumn ?? ViewColumn.Beside);
     }
 
     close() {

--- a/client/src/modelView/ProblemConstraintsView.ts
+++ b/client/src/modelView/ProblemConstraintsView.ts
@@ -156,8 +156,8 @@ class ProblemConstraintsRendererDelegate {
     }
 
     private addNamedCondition(namedCondition: NamedConditionConstraint, index: number): number {
-        let key = namedCondition.name || namedCondition.condition?.getText() || "unnamed";
-        this.nodes.set(key, new NamedConditionNode(index, namedCondition.name || "", namedCondition.condition?.getText() || "unspecified condition"));
+        let key = namedCondition.name ?? namedCondition.condition?.getText() ?? "unnamed";
+        this.nodes.set(key, new NamedConditionNode(index, namedCondition.name ?? "", namedCondition.condition?.getText() ?? "unspecified condition"));
         return index;
     }
 

--- a/client/src/modelView/ProblemView.ts
+++ b/client/src/modelView/ProblemView.ts
@@ -80,7 +80,7 @@ export abstract class ProblemView<TRendererOptions, TRenderData> extends Disposa
         let domainInfoAssigned: DomainInfo;
         let error: Error;
         try {
-            domainInfoAssigned = domainInfo || getDomainFileForProblem(problemInfo, this.codePddlWorkspace);
+            domainInfoAssigned = domainInfo ?? getDomainFileForProblem(problemInfo, this.codePddlWorkspace);
         }
         catch (ex) {
             error = ex;

--- a/client/src/modelView/ProblemViewPanel.ts
+++ b/client/src/modelView/ProblemViewPanel.ts
@@ -56,7 +56,7 @@ export class ProblemViewPanel extends BaseViewPanel {
     }
 
     reveal(displayColumn?: ViewColumn): void {
-        this.panel.reveal(displayColumn || ViewColumn.Beside);
+        this.panel.reveal(displayColumn ?? ViewColumn.Beside);
     }
 
     close() {

--- a/client/src/planning/PlanReportGenerator.ts
+++ b/client/src/planning/PlanReportGenerator.ts
@@ -47,7 +47,7 @@ export class PlanReportGenerator {
     async generateHtml(plans: Plan[], planId: number = -1): Promise<string> {
         let selectedPlan = planId < 0 ? plans.length - 1 : planId;
 
-        let maxCost = Math.max(...plans.map(plan => plan.cost || 0));
+        let maxCost = Math.max(...plans.map(plan => plan.cost ?? 0));
 
         let planSelectors = plans.map((plan, planIndex) => this.renderPlanSelector(plan, planIndex, selectedPlan, maxCost)).join(" ");
 
@@ -92,7 +92,7 @@ export class PlanReportGenerator {
         let className = "planSelector";
         if (planIndex === selectedPlan) { className += " planSelector-selected"; }
 
-        let normalizedCost = (plan.cost || 0) / maxCost * 100;
+        let normalizedCost = (plan.cost ?? 0) / maxCost * 100;
         let costRounded = plan.cost ? plan.cost.toFixed(DIGITS) : NaN;
         let tooltip = `Plan #${planIndex}
 Metric value / cost: ${plan.cost}
@@ -440,16 +440,16 @@ ${stepsInvolvingThisObject}
     }
 
     computePlanHeadDuration(step: PlanStep, plan: Plan): number {
-        if (plan.now === undefined) { return step.getDuration() || DEFAULT_EPSILON; }
+        if (plan.now === undefined) { return step.getDuration() ?? DEFAULT_EPSILON; }
         else if (step.getEndTime() < plan.now) {
-            if (step.commitment === PlanStepCommitment.Committed) { return step.getDuration() || DEFAULT_EPSILON; }
+            if (step.commitment === PlanStepCommitment.Committed) { return step.getDuration() ?? DEFAULT_EPSILON; }
             else { return 0; } // the end was not committed yet
         }
         else if (step.getStartTime() >= plan.now) { return 0; }
         else {
             switch (step.commitment) {
                 case PlanStepCommitment.Committed:
-                    return step.getDuration() || DEFAULT_EPSILON;
+                    return step.getDuration() ?? DEFAULT_EPSILON;
                 case PlanStepCommitment.EndsInRelaxedPlan:
                     return 0;
                 case PlanStepCommitment.StartsInRelaxedPlan:
@@ -469,13 +469,13 @@ ${stepsInvolvingThisObject}
     computeRelaxedWidth(step: PlanStep, plan: Plan): number {
         let planHeadDuration = this.computePlanHeadDuration(step, plan);
         // remove the part of the planStep duration that belongs to the planhead part
-        let relaxedDuration = (step.getDuration() || DEFAULT_EPSILON) - planHeadDuration;
+        let relaxedDuration = (step.getDuration() ?? DEFAULT_EPSILON) - planHeadDuration;
         return this.toViewCoordinates(relaxedDuration, plan);
     }
 
     /** Converts the _time_ argument to view coordinates */
     toViewCoordinates(time: number | undefined, plan: Plan): number {
-        return (time || 0) / plan.makespan * this.options.displayWidth;
+        return (time ?? 0) / plan.makespan * this.options.displayWidth;
     }
 
     getActionColor(step: PlanStep, domain?: DomainInfo): string {

--- a/client/src/planning/PlannerAsyncService.ts
+++ b/client/src/planning/PlannerAsyncService.ts
@@ -38,7 +38,7 @@ export class PlannerAsyncService extends PlannerService {
         let configuration = await this.getConfiguration();
         if (!configuration) { return null; }
 
-        configuration.planFormat = configuration.planFormat || 'JSON';
+        configuration.planFormat = configuration.planFormat ?? 'JSON';
         if ("timeout" in configuration) {
             this.timeout = configuration.timeout;
         }

--- a/client/src/planning/PlannerService.ts
+++ b/client/src/planning/PlannerService.ts
@@ -94,10 +94,10 @@ export abstract class PlannerService extends Planner {
         for (var index = 0; index < planSteps.length; index++) {
             var planStep = planSteps[index];
             let fullActionName = (<string>planStep["name"]).replace('(', '').replace(')', '');
-            let time = planStep["time"] || (index + 1) * planParser.options.epsilon;
+            let time = planStep["time"] ?? (index + 1) * planParser.options.epsilon;
             let duration = planStep["duration"];
             let isDurative = duration !== undefined && duration !== null;
-            duration = duration || planParser.options.epsilon;
+            duration = duration ?? planParser.options.epsilon;
             let planStepObj = new PlanStep(time, fullActionName, isDurative, duration, index);
             planParser.appendStep(planStepObj);
         }

--- a/client/src/ptest/PTestExplorer.ts
+++ b/client/src/ptest/PTestExplorer.ts
@@ -15,7 +15,7 @@ import { Test, TestOutcome } from './Test';
 import { PTestTreeDataProvider, PTestNode, PTestNodeKind } from './PTestTreeDataProvider';
 import { GeneratedDocumentContentProvider } from './GeneratedDocumentContentProvider';
 import { Planning } from '../planning/planning';
-import { PlanningOutcome } from '../planning/PlanningResult';
+import { PlanningOutcome, PlanningResult } from '../planning/PlanningResult';
 import { Plan } from '../../../common/src/Plan';
 import { PddlPlanParser } from '../../../common/src/PddlPlanParser';
 import { TestsManifest } from './TestsManifest';
@@ -291,7 +291,7 @@ export class PTestExplorer {
 
                 if (result.outcome === PlanningOutcome.FAILURE) {
                     this.outputTestResult(test, TestOutcome.FAILED, result.elapsedTime, result.error);
-                    reject(new Error(result.error || "Unknown error while planning."));
+                    reject(new Error(result.error ?? "Unknown error while planning."));
                     return;
                 } else if (result.outcome === PlanningOutcome.KILLED) {
                     this.outputTestResult(test, TestOutcome.SKIPPED, result.elapsedTime, 'Killed by the user.');
@@ -308,7 +308,7 @@ export class PTestExplorer {
                         this.assertMatchesAnExpectedPlan(result, test);
                     }
                     catch (err) {
-                        this.outputTestResult(test, TestOutcome.FAILED, result.elapsedTime, "Failed to compare plan to expected plans. Error: " + err.message || err);
+                        this.outputTestResult(test, TestOutcome.FAILED, result.elapsedTime, "Failed to compare plan to expected plans. Error: " + err.message ?? err);
                     }
                 }
                 else {
@@ -328,7 +328,7 @@ export class PTestExplorer {
         });
     }
 
-    private assertMatchesAnExpectedPlan(result: import("c:/NotBackedUp/c/GitHub/vscode-pddl/client/src/planning/PlanningResult").PlanningResult, test: Test) {
+    private assertMatchesAnExpectedPlan(result: PlanningResult, test: Test) {
         let success = result.plans.every(plan => test.getExpectedPlans()
             .map(expectedPlanFileName => test.toAbsolutePath(expectedPlanFileName))
             .some(expectedPlanPath => this.areSame(plan, this.loadPlan(expectedPlanPath))));

--- a/client/src/ptest/PTestReportView.ts
+++ b/client/src/ptest/PTestReportView.ts
@@ -97,7 +97,7 @@ export class PTestReportView {
         let testResult = this.report.getTestResultOrThrow(test);
         let elapsedTime = testResult.elapsedTime ? `${(testResult.elapsedTime / 1000).toFixed(2)}` : '';
         let viewTestLink = `<a  href="#" onclick="openTest('${test.getUri().toString()}')" title="Open test case.">&#128065;</a>`;
-        return `<tr><td>${test.getLabel()} ${viewTestLink}</td><td>${testResult.outcomeChar}</td><td>${elapsedTime}</td><td>${testResult.error || ""}</td></tr>`;
+        return `<tr><td>${test.getLabel()} ${viewTestLink}</td><td>${testResult.outcomeChar}</td><td>${elapsedTime}</td><td>${testResult.error ?? ""}</td></tr>`;
     }
 
     async handleMessage(message: any): Promise<void> {

--- a/client/src/ptest/Test.ts
+++ b/client/src/ptest/Test.ts
@@ -49,7 +49,7 @@ export class Test {
         let domain = json[DOMAIN];
         let problem = json[PROBLEM];
         let options = json[OPTIONS];
-        let expectedPlans = json[EXPECTED_PLANS] || [];
+        let expectedPlans = json[EXPECTED_PLANS] ?? [];
 
         let preProcessSettings = json[PRE_PROCESSOR];
         let preProcessor: PreProcessor | undefined;
@@ -102,7 +102,7 @@ export class Test {
     }
 
     getDomain(): string {
-        return this.domain || this.manifest.defaultDomain || throwForUndefined('domain');
+        return this.domain ?? this.manifest.defaultDomain ?? throwForUndefined('domain');
     }
 
     getDomainUri(): Uri {
@@ -110,7 +110,7 @@ export class Test {
     }
 
     getProblem(): string {
-        return this.problem || this.manifest.defaultProblem || throwForUndefined("problem");
+        return this.problem ?? this.manifest.defaultProblem ?? throwForUndefined("problem");
     }
 
     getProblemUri(): Uri {
@@ -122,7 +122,7 @@ export class Test {
     }
 
     getLabel(): string {
-        return this.label || this.problem || this.getProblem() + ` (${this.index + 1})`;
+        return this.label ?? this.problem ?? this.getProblem() + ` (${this.index + 1})`;
     }
 
     getDescription(): string {
@@ -130,7 +130,7 @@ export class Test {
     }
 
     getOptions(): string | undefined {
-        return this.options || this.manifest.defaultOptions;
+        return this.options ?? this.manifest.defaultOptions;
     }
 
     getPreProcessor(): PreProcessor | undefined {

--- a/client/src/searchDebugger/SearchDebugger.ts
+++ b/client/src/searchDebugger/SearchDebugger.ts
@@ -170,7 +170,7 @@ export class SearchDebugger implements PlannerOptionsProvider {
             this.stop();
         }
         catch (ex) {
-            window.showErrorMessage("Error stopping search debug listener: " + (ex.message || ex));
+            window.showErrorMessage("Error stopping search debug listener: " + (ex.message ?? ex));
         }
     }
 

--- a/client/src/searchDebugger/SearchDebuggerView.ts
+++ b/client/src/searchDebugger/SearchDebuggerView.ts
@@ -180,7 +180,7 @@ export class SearchDebuggerView {
     }
 
     showAllStates(): void {
-        let allStates = this.search?.getStates() || [];
+        let allStates = this.search?.getStates() ?? [];
         new Promise(_ => this.postMessage({ command: 'showAllStates', state: allStates }))
             .catch(reason => console.log(reason));
     }
@@ -189,7 +189,7 @@ export class SearchDebuggerView {
         try {
             this.showStatePlan(state.id);
         } catch (ex) {
-            window.showErrorMessage(ex.message || ex);
+            window.showErrorMessage(ex.message ?? ex);
         }
     }
 

--- a/client/src/searchDebugger/StateToPlan.ts
+++ b/client/src/searchDebugger/StateToPlan.ts
@@ -34,7 +34,7 @@ export class StateToPlan {
 
         let planSteps = planStepBuilders.map(step => step.toPalStep(state.earliestTime));
 
-        let helpfulActions = state.helpfulActions || [];
+        let helpfulActions = state.helpfulActions ?? [];
 
         return new Plan(planSteps, this.domain, this.problem, state.earliestTime, helpfulActions);
     }

--- a/client/src/session/StudentNameParser.ts
+++ b/client/src/session/StudentNameParser.ts
@@ -11,13 +11,15 @@ export class StudentNameParser {
         return input.split(';')
             .map(name => name.trim())
             .filter(name => name.length) // skip empty names e.g. after a trailing semicolon
-            .map(name => this.parseName(name));
+            .map(name => this.parseName(name))
+            .filter(student => !!student)
+            .map(student => student!);
     }
 
-    validateClassroomNames(input: string): string {
+    validateClassroomNames(input: string): string | null {
         let invalidNames = input.split(';')
             .map(name => name.trim())
-            .filter(name => name.length) // skip empty names e.g. after a trailing semicolon
+            .filter(name => name.length > 0) // skip empty names e.g. after a trailing semicolon
             .filter(name => !this.parseName(name));
 
         if (invalidNames.length) {
@@ -37,13 +39,13 @@ export class StudentNameParser {
         this.NAME_PATTERN.lastIndex = 0;
         this.NAME_AND_EMAIL_PATTERN.lastIndex = 0;
 
-        var match: RegExpMatchArray;
+        var match: RegExpMatchArray | null;
 
         if (match = name.match(this.EMAIL_PATTERN)) {
             return new StudentName(match[0], match[0]); // it is valid
         }
         else if (match = name.match(this.NAME_PATTERN)) {
-            return new StudentName(match[0], null); // it is valid
+            return new StudentName(match[0]); // it is valid, but email address was not included
         }
         else if (match = name.match(this.NAME_AND_EMAIL_PATTERN)) {
             let emailPart = match[3].trim();
@@ -58,7 +60,7 @@ export class StudentNameParser {
 }
 
 export class StudentName {
-    constructor(public readonly name: string, public readonly email: string) { }
+    constructor(public readonly name: string, public readonly email?: string) { }
 
     getEffectiveName(): string {
         return this.name;

--- a/client/src/symbols/ModelHierarchyProvider.ts
+++ b/client/src/symbols/ModelHierarchyProvider.ts
@@ -34,7 +34,7 @@ export class ModelHierarchyProvider implements HoverProvider {
         window.visibleTextEditors.forEach(editor => this.scheduleDecoration(editor));
     }
 
-    scheduleDecoration(editor: TextEditor): void {
+    scheduleDecoration(editor: TextEditor | undefined): void {
         if (editor && editor.visibleRanges.length && isPddl(editor.document)) {
 
             this.triggerDecorationRefresh(editor);
@@ -205,7 +205,7 @@ export class ModelHierarchyProvider implements HoverProvider {
     }
 
 
-    private getReferences(references: Location[], domainInfo: DomainInfo, symbolInfo: SymbolInfo, document: TextDocument) {
+    private getReferences(references: Location[], domainInfo: DomainInfo, symbolInfo: SymbolInfo, document: TextDocument): VariableReferenceInfo[] {
         return references
             .filter(r => r.uri.toString() === domainInfo.fileUri) // limit this to the domain file only
             .map(r => new ModelHierarchy(domainInfo!).getReferenceInfo((<VariableInfo>symbolInfo).variable, document.offsetAt(r.range.start) + 1));
@@ -235,6 +235,6 @@ export class ModelHierarchyProvider implements HoverProvider {
     }
 
     private createAccessKindDocumentation(referenceInfos: VariableReferenceInfo[], documentation: MarkdownString): void {
-        referenceInfos.forEach(ri => documentation.appendMarkdown(`\n- \`${ri.structure.getNameOrEmpty()}\` ${ri.getTimeQualifier()} ${ri.part}`).appendCodeblock(ri.relevantCode, PDDL));
+        referenceInfos.forEach(ri => documentation.appendMarkdown(`\n- \`${ri.structure.getNameOrEmpty()}\` ${ri.getTimeQualifier()} ${ri.part}`).appendCodeblock(ri.relevantCode ?? '', PDDL));
     }
 }

--- a/client/src/symbols/SymbolInfoProvider.ts
+++ b/client/src/symbols/SymbolInfoProvider.ts
@@ -62,26 +62,23 @@ export class SymbolInfoProvider implements DocumentSymbolProvider, DefinitionPro
             let containerName = '';
 
             let actionSymbols = domainInfo.getActions()
-                // only support those that have a name and where the location is known
-                .filter(action => action.name && action.getLocation())
                 .map(action =>
-                    new SymbolInformation(action.name!, SymbolKind.Module, containerName, SymbolUtils.toLocation(document, action.getLocation()!)));
+                    new SymbolInformation(action.name ?? "unnamed action", SymbolKind.Module, containerName,
+                        SymbolUtils.toLocation(document, action.getLocation())));
 
             if (!domainInfo.getProcesses()) { throw new Error(`Domain not parsed yet: ` + domainInfo.fileUri);}
             
             let processSymbols = domainInfo.getProcesses()!
-                // only support those that have a name and where the location is known
-                .filter(process => process.name && process.getLocation())
                 .map(process =>
-                    new SymbolInformation(process.name!, SymbolKind.Struct, containerName, SymbolUtils.toLocation(document, process.getLocation()!)));
+                    new SymbolInformation(process.name ?? "unnamed process", SymbolKind.Struct, containerName,
+                        SymbolUtils.toLocation(document, process.getLocation())));
 
             if (!domainInfo.getEvents()) { throw new Error(`Domain not parsed yet: ` + domainInfo.fileUri);}
 
             let eventSymbols = domainInfo.getEvents()!
-                // only support those that have a name and where the location is known
-                .filter(event => event.name && event.getLocation())
                 .map(event =>
-                    new SymbolInformation(event.name!, SymbolKind.Event, containerName, SymbolUtils.toLocation(document, event.getLocation()!)));
+                    new SymbolInformation(event.name ?? "unnamed event", SymbolKind.Event, containerName,
+                        SymbolUtils.toLocation(document, event.getLocation())));
 
             let predicateSymbols = domainInfo.getPredicates().map(variable =>
                 new SymbolInformation(variable.declaredName, SymbolKind.Boolean, containerName, SymbolUtils.toLocation(document, variable.getLocation())));

--- a/client/src/symbols/SymbolUtils.ts
+++ b/client/src/symbols/SymbolUtils.ts
@@ -58,10 +58,10 @@ export class SymbolUtils {
                 );
             }
             let actionFound = domainInfo.getActions().find(a => a.name?.toLowerCase() === symbolName);
-            if (actionFound && actionFound.getLocation()) {
+            if (actionFound) {
                 return new ActionInfo(
                     this.createActionHover(symbol.range, actionFound),
-                    new Location(this.toUri(domainInfo.fileUri), toRange(actionFound.getLocation()!)),
+                    new Location(this.toUri(domainInfo.fileUri), toRange(actionFound.getLocation())),
                     actionFound
                 );
             }
@@ -178,7 +178,7 @@ export class SymbolUtils {
         if (action.isDurative()) { label = 'Durative ' + label; }
 
         let doc = new MarkdownString(`**${label}**`)
-            .appendCodeblock(action.name || "", 'pddl');
+            .appendCodeblock(action.name ?? "", 'pddl');
 
         if (action.parameters.length) {
             doc = doc.appendMarkdown('Parameters:' + END_LINE + END_LINE);

--- a/client/src/test/suite/PddlCompletionItemProvider.test.ts
+++ b/client/src/test/suite/PddlCompletionItemProvider.test.ts
@@ -57,7 +57,7 @@ suite('PDDL Completion Item Provider', () => {
         let items = await testDomainProvider(inputTextHead, ch, inputTextTail, { triggerKind: vscode.CompletionTriggerKind.Invoke, triggerCharacter: ch });
 
         // THEN
-        assert.deepStrictEqual(items.map(i => i.filterText || i.label), [
+        assert.deepStrictEqual(items.map(i => i.filterText ?? i.label), [
             // '(domain',
             '(:requirements',
             '(:types',
@@ -83,7 +83,7 @@ suite('PDDL Completion Item Provider', () => {
         let items = await testDomainProvider(inputTextHead, ch, inputTextTail, { triggerKind: vscode.CompletionTriggerKind.TriggerCharacter, triggerCharacter: ch });
 
         // THEN
-        assert.deepStrictEqual(items.map(i => i.filterText || i.label), [
+        assert.deepStrictEqual(items.map(i => i.filterText ?? i.label), [
             // '(domain',
             '(:requirements',
             '(:types',
@@ -109,7 +109,7 @@ suite('PDDL Completion Item Provider', () => {
         let items = await testDomainProvider(inputTextHead, ch, inputTextTail, { triggerKind: vscode.CompletionTriggerKind.TriggerCharacter, triggerCharacter: ch });
 
         // THEN
-        assert.deepStrictEqual(items.map(i => i.filterText || i.label), [
+        assert.deepStrictEqual(items.map(i => i.filterText ?? i.label), [
             '(:requirements',
             '(:types',
             '(:constants',
@@ -136,7 +136,7 @@ suite('PDDL Completion Item Provider', () => {
         let items = await testDomainProvider(inputTextHead, ch, inputTextTail, { triggerKind: vscode.CompletionTriggerKind.Invoke, triggerCharacter: ch });
 
         // THEN
-        items.some(item => (item.filterText || item.label) === ':strips');
+        items.some(item => (item.filterText ?? item.label) === ':strips');
         items.forEach(item => assert.strictEqual(item.range, undefined, `Range of ${item.label} should be undefined`));
     });
 
@@ -150,7 +150,7 @@ suite('PDDL Completion Item Provider', () => {
         let items = await testDomainProvider(inputTextHead, ch, inputTextTail, { triggerKind: vscode.CompletionTriggerKind.TriggerCharacter, triggerCharacter: ch });
 
         // THEN
-        items.some(item => (item.filterText || item.label) === ':strips');
+        items.some(item => (item.filterText ?? item.label) === ':strips');
         items.forEach(item => assert.deepStrictEqual(item.range, new vscode.Range(0, inputTextHead.length, 0, inputTextHead.length + 1), `Range of '${item.label}'`));
     });
 
@@ -166,7 +166,7 @@ suite('PDDL Completion Item Provider', () => {
         let items = await testDomainProvider(inputTextHead, ch, inputTextTail, { triggerKind: vscode.CompletionTriggerKind.Invoke, triggerCharacter: ch });
 
         // THEN
-        assert.deepStrictEqual(items.map(i => i.filterText || i.label), [
+        assert.deepStrictEqual(items.map(i => i.filterText ?? i.label), [
             ':parameters',
             ':precondition',
             ':effect',
@@ -184,7 +184,7 @@ suite('PDDL Completion Item Provider', () => {
         let items = await testDomainProvider(inputTextHead, ch, inputTextTail, { triggerKind: vscode.CompletionTriggerKind.Invoke, triggerCharacter: ch });
 
         // THEN
-        assert.deepStrictEqual(items.map(i => i.filterText || i.label), [
+        assert.deepStrictEqual(items.map(i => i.filterText ?? i.label), [
             ':parameters',
             ':precondition',
             ':effect',
@@ -202,7 +202,7 @@ suite('PDDL Completion Item Provider', () => {
         let items = await testDomainProvider(inputTextHead, ch, inputTextTail, { triggerKind: vscode.CompletionTriggerKind.Invoke, triggerCharacter: ch });
 
         // THEN
-        assert.deepStrictEqual(items.map(i => i.filterText || i.label), [
+        assert.deepStrictEqual(items.map(i => i.filterText ?? i.label), [
             ':effect',
         ]);
         items.forEach(item => assert.deepStrictEqual(item.range, new vscode.Range(1, 0, 1, 1), `Range of '${item.label}'`));
@@ -220,7 +220,7 @@ suite('PDDL Completion Item Provider', () => {
         let items = await testDomainProvider(inputTextHead, ch, inputTextTail, { triggerKind: vscode.CompletionTriggerKind.Invoke, triggerCharacter: ch });
 
         // THEN
-        assert.deepStrictEqual(items.map(i => i.filterText || i.label), [
+        assert.deepStrictEqual(items.map(i => i.filterText ?? i.label), [
             ':parameters',
             ':duration',
             ':condition',
@@ -239,7 +239,7 @@ suite('PDDL Completion Item Provider', () => {
         let items = await testDomainProvider(inputTextHead, ch, inputTextTail, { triggerKind: vscode.CompletionTriggerKind.Invoke, triggerCharacter: ch });
 
         // THEN
-        assert.deepStrictEqual(items.map(i => i.filterText || i.label), [
+        assert.deepStrictEqual(items.map(i => i.filterText ?? i.label), [
             ':parameters',
             ':duration',
             ':condition',
@@ -262,7 +262,7 @@ suite('PDDL Completion Item Provider', () => {
         // THEN
         assertSnippetIncludes(items, "(not", 'p1,p2');
         assertSnippetIncludes(items, "(assign", '(assign (${1:new_function}) ${2:0})$0');
-        assert.deepStrictEqual(items.map(i => i.filterText || i.label), [
+        assert.deepStrictEqual(items.map(i => i.filterText ?? i.label), [
             '(not',
             '(assign',
             '(increase',
@@ -285,7 +285,7 @@ suite('PDDL Completion Item Provider', () => {
         // THEN
         assertSnippetIncludes(items, "(not", 'p1,p2');
         assertSnippetIncludes(items, "(assign", '(assign (${1:new_function}) ${2:0})$0');
-        assert.deepStrictEqual(items.map(i => i.filterText || i.label), [
+        assert.deepStrictEqual(items.map(i => i.filterText ?? i.label), [
             '(not',
             '(assign',
             '(increase',
@@ -309,7 +309,7 @@ suite('PDDL Completion Item Provider', () => {
         // THEN
         assertSnippetIncludes(items, "(increase", 'f1');
         assertSnippetIncludes(items, "(decrease", '(decrease (${1|f1|}) (* #t ${2:1.0}))$0');
-        assert.deepStrictEqual(items.map(i => i.filterText || i.label), [
+        assert.deepStrictEqual(items.map(i => i.filterText ?? i.label), [
             '(at start',
             '(at end',
             '(increase',
@@ -331,7 +331,7 @@ suite('PDDL Completion Item Provider', () => {
         // THEN
         assertSnippetIncludes(items, "(increase", 'f1');
         assertSnippetIncludes(items, "(decrease", '(decrease (${1|f1|}) (* #t ${2:1.0}))$0');
-        assert.deepStrictEqual(items.map(i => i.filterText || i.label), [
+        assert.deepStrictEqual(items.map(i => i.filterText ?? i.label), [
             '(increase',
             '(decrease',
             '(forall',
@@ -352,7 +352,7 @@ suite('PDDL Completion Item Provider', () => {
         let items = await testDomainProvider(inputTextHead, ch, inputTextTail, { triggerKind: vscode.CompletionTriggerKind.Invoke, triggerCharacter: ch });
 
         // THEN
-        assert.deepStrictEqual(items.map(i => i.filterText || i.label), [
+        assert.deepStrictEqual(items.map(i => i.filterText ?? i.label), [
             '(at start',
             '(at end',
             '(over all',
@@ -372,7 +372,7 @@ suite('PDDL Completion Item Provider', () => {
         let items = await testDomainProvider(inputTextHead, ch, inputTextTail, { triggerKind: vscode.CompletionTriggerKind.TriggerCharacter, triggerCharacter: ch });
 
         // THEN
-        assert.deepStrictEqual(items.map(i => i.filterText || i.label), [
+        assert.deepStrictEqual(items.map(i => i.filterText ?? i.label), [
             '?pfa',
             '?pa-1',
             '?pa_2',
@@ -393,7 +393,7 @@ suite('PDDL Completion Item Provider', () => {
         let items = await testProblemProvider(inputTextHead, ch, inputTextTail, { triggerKind: vscode.CompletionTriggerKind.Invoke, triggerCharacter: ch });
     
         // THEN
-        assert.deepStrictEqual(items.map(i => i.filterText || i.label), [
+        assert.deepStrictEqual(items.map(i => i.filterText ?? i.label), [
             '(problem',
             '(:domain',
             '(:requirements',
@@ -416,7 +416,7 @@ suite('PDDL Completion Item Provider', () => {
         let items = await testProblemProvider(inputTextHead, ch, inputTextTail, { triggerKind: vscode.CompletionTriggerKind.TriggerCharacter, triggerCharacter: ch });
     
         // THEN
-        assert.deepStrictEqual(items.map(i => i.filterText || i.label), [
+        assert.deepStrictEqual(items.map(i => i.filterText ?? i.label), [
             '(problem',
             '(:domain',
             '(:requirements',
@@ -439,7 +439,7 @@ suite('PDDL Completion Item Provider', () => {
         let items = await testProblemProvider(inputTextHead, ch, inputTextTail, { triggerKind: vscode.CompletionTriggerKind.TriggerCharacter, triggerCharacter: ch });
     
         // THEN
-        assert.deepStrictEqual(items.map(i => i.filterText || i.label), [
+        assert.deepStrictEqual(items.map(i => i.filterText ?? i.label), [
             '(:domain',
             '(:requirements',
             '(:objects',

--- a/client/src/utils.ts
+++ b/client/src/utils.ts
@@ -64,9 +64,9 @@ function asWebviewUri(localUri: Uri, webview?: Webview): Uri {
 }
 
 function createContentSecurityPolicy(webview: Webview, options: WebViewHtmlOptions): string {
-    let externalStyles = options.externalStyles?.map(uri => uri.toString()).join(" ") || "";
-    let externalScripts = options.externalScripts?.map(uri => uri.toString()).join(" ") || "";
-    let externalImages = options.externalImages?.map(uri => uri.toString()).join(" ") || "";
+    let externalStyles = options.externalStyles?.map(uri => uri.toString()).join(" ") ?? "";
+    let externalScripts = options.externalScripts?.map(uri => uri.toString()).join(" ") ?? "";
+    let externalImages = options.externalImages?.map(uri => uri.toString()).join(" ") ?? "";
     return `<meta http-equiv="Content-Security-Policy"
 \t\tcontent="default-src 'none'; img-src ${webview.cspSource} ${externalImages} https:; script-src ${webview.cspSource} ${externalScripts} 'unsafe-inline'; style-src ${webview.cspSource} ${externalStyles} 'unsafe-inline';"
 \t/>`;
@@ -146,6 +146,15 @@ export function showError(reason: any): void {
 
 export function throwForUndefined<T>(part: string): T {
     throw new Error(`No ${part} defined.`);
+}
+
+export function assertDefined<T>(value: T | undefined, message: string): T {
+    if (value === undefined || value === null) {
+        throw new Error("Assertion error: " + message);
+    }
+    else {
+        return value!;
+    }
 }
 
 /**

--- a/client/src/validation/Val.ts
+++ b/client/src/validation/Val.ts
@@ -28,11 +28,11 @@ export class Val {
 
         context.subscriptions.push(instrumentOperationAsVsCodeCommand(VAL_DOWNLOAD_COMMAND, async (options: ValDownloadOptions) => {
             try {
-                let userAgreesToDownload = (options && options.bypassConsent) || await this.promptForConsent();
+                let userAgreesToDownload = options?.bypassConsent ?? await this.promptForConsent();
                 if (!userAgreesToDownload) { return; }
                 await this.downloadConfigureAndCleanUp();
             } catch (ex) {
-                window.showErrorMessage(ex.message || ex);
+                window.showErrorMessage(ex.message ?? ex);
             }
         }));
 

--- a/client/src/validation/ValDownloadReminder.ts
+++ b/client/src/validation/ValDownloadReminder.ts
@@ -56,7 +56,7 @@ export class ValDownloadReminder {
         try {
             await this.val.downloadConfigureAndCleanUp();
         } catch (ex) {
-            window.showErrorMessage(ex.message || ex);
+            window.showErrorMessage(ex.message ?? ex);
         }
     }
 }

--- a/client/src/workspace/CodePddlWorkspace.ts
+++ b/client/src/workspace/CodePddlWorkspace.ts
@@ -146,7 +146,7 @@ function subscribeToWorkspace(pddlWorkspace: CodePddlWorkspace, context: Extensi
 async function revealAction(domainInfo: DomainInfo, actionName: String) {
     let document = await workspace.openTextDocument(Uri.parse(domainInfo.fileUri));
     let actionFound = domainInfo.getActions().find(a => a?.name?.toLowerCase() === actionName.toLowerCase());
-    let actionRange = actionFound && actionFound.getLocation() && toRange(actionFound.getLocation()!);
+    let actionRange = actionFound && toRange(actionFound.getLocation());
     let openEditor = window.visibleTextEditors.find(e => e.document.uri.toString() === document.uri.toString());
     if (openEditor && actionRange) {
         openEditor.revealRange(actionRange, TextEditorRevealType.AtTop);

--- a/client/src/workspace/workspaceUtils.ts
+++ b/client/src/workspace/workspaceUtils.ts
@@ -83,7 +83,7 @@ export class NoProblemAssociated extends Error {
 
 export class NoDomainAssociated extends Error {
     constructor(public readonly problem: ProblemInfo, message?: string) {
-        super(message || NoDomainAssociated.getMessage(problem));
+        super(message ?? NoDomainAssociated.getMessage(problem));
     }
 
     static readonly DIAGNOSTIC_CODE = "NoAssociatedDomain";

--- a/common/package-lock.json
+++ b/common/package-lock.json
@@ -2093,7 +2093,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "merge-descriptors": {
@@ -2155,7 +2155,7 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
@@ -2182,7 +2182,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -6296,9 +6296,9 @@
       }
     },
     "typescript": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.2.tgz",
-      "integrity": "sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==",
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.2.tgz",
+      "integrity": "sha512-EgOVgL/4xfVrCMbhYKUQTdF37SQn4Iw73H5BgCrF1Abdun7Kwy/QZsE/ssAy0y4LxBbvua3PIbFsbRczWWnDdQ==",
       "dev": true
     },
     "union-value": {

--- a/common/package.json
+++ b/common/package.json
@@ -41,6 +41,6 @@
     "@types/uuid": "^3.4.4",
     "mocha": "^6.2.1",
     "tslint": "^5.20.0",
-    "typescript": "^3.7.2"
+    "typescript": "^3.7.3"
   }
 }

--- a/common/src/DerivedVariableParser.ts
+++ b/common/src/DerivedVariableParser.ts
@@ -40,7 +40,7 @@ export class DerivedVariablesParser {
     }
 
     static getDocumentationAbove(derivedNode: PddlSyntaxNode): string[] {
-        let siblingNodes = derivedNode.getParent()?.getChildren() || [];
+        let siblingNodes = derivedNode.getParent()?.getChildren() ?? [];
 
         let indexOfThisNode = siblingNodes.indexOf(derivedNode);
 

--- a/common/src/DocumentPositionResolver.ts
+++ b/common/src/DocumentPositionResolver.ts
@@ -3,6 +3,11 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 
+import { PddlSyntaxNode } from "./PddlSyntaxNode";
+
+/**
+ * Abstract document position resolve. It translates document text offsets to Position or Range.
+ */
 export abstract class DocumentPositionResolver {
     abstract resolveToPosition(offset: number): PddlPosition;
     
@@ -14,6 +19,10 @@ export abstract class DocumentPositionResolver {
         let positionAtOffset = this.resolveToPosition(offset);
 
         return range.includes(positionAtOffset); 
+    }
+
+    nodeToRange(node: PddlSyntaxNode): PddlRange {
+        return this.resolveToRange(node.getStart(), node.getEnd());
     }
 }
 

--- a/common/src/DurativeActionParser.ts
+++ b/common/src/DurativeActionParser.ts
@@ -44,11 +44,10 @@ export class DurativeActionParser {
         let durationNode = actionNode.getKeywordOpenBracket('duration');
         let conditionNode = actionNode.getKeywordOpenBracket('condition');
         let effectNode = actionNode.getKeywordOpenBracket('effect');
-        
-        this.action = new DurativeAction(actionName, parameters, durationNode, conditionNode, effectNode);
         let location = PddlRange.from(positionResolver
             .resolveToPosition(actionNode.getStart()), positionResolver.resolveToPosition(actionNode.getEnd()));
-        this.action.setLocation(location);
+        
+        this.action = new DurativeAction(actionName, parameters, location, durationNode, conditionNode, effectNode);
         this.action.setDocumentation(DerivedVariablesParser.getDocumentationAbove(actionNode));
     }
 

--- a/common/src/FileInfo.ts
+++ b/common/src/FileInfo.ts
@@ -53,7 +53,7 @@ export abstract class FileInfo {
     }
 
     update(version: number, text: string, force: boolean = false): boolean {
-        let isNewerVersion = version > this.version || force;
+        let isNewerVersion = (version > this.version) || force;
         if (isNewerVersion) {
             this.setStatus(FileStatus.Dirty);
             this.version = version;

--- a/common/src/InstantActionParser.ts
+++ b/common/src/InstantActionParser.ts
@@ -32,10 +32,9 @@ export class InstantActionParser {
         let parameters = parametersNode ? parseParameters(parametersNode.getNestedNonCommentText()) : [];
         let conditionNode = actionNode.getKeywordOpenBracket('precondition');
         let effectNode = actionNode.getKeywordOpenBracket('effect');
-        this.action = new InstantAction(actionName, parameters, conditionNode, effectNode);
         let location = PddlRange.from(positionResolver
             .resolveToPosition(actionNode.getStart()), positionResolver.resolveToPosition(actionNode.getEnd()));
-        this.action.setLocation(location);
+        this.action = new InstantAction(actionName, parameters, location, conditionNode, effectNode);
         this.action.setDocumentation(DerivedVariablesParser.getDocumentationAbove(actionNode));
     }
 

--- a/common/src/PddlConstraintsParser.ts
+++ b/common/src/PddlConstraintsParser.ts
@@ -38,10 +38,10 @@ export class PddlConstraintsParser {
             switch (token) {
                 case 'name':
                 case 'named-condition':
-                    return this.parseNamedCondition(node, children.slice(1)) || new Constraint(node);
+                    return this.parseNamedCondition(node, children.slice(1)) ?? new Constraint(node);
                 case strictlyAfterToken:
                 case 'after':
-                    return this.parseAfter(node, children.slice(1), token === strictlyAfterToken) || new Constraint(node);
+                    return this.parseAfter(node, children.slice(1), token === strictlyAfterToken) ?? new Constraint(node);
                 default:
                     return new Constraint(node);
             }

--- a/common/src/PddlInheritanceParser.ts
+++ b/common/src/PddlInheritanceParser.ts
@@ -39,7 +39,7 @@ export class PddlInheritanceParser {
 
         // connect orphan types to the 'object' type
         let orphans = inheritance.getVertices()
-            .filter(v => !inheritance.getVerticesWithEdgesFrom(v)?.length || 0)
+            .filter(v => !inheritance.getVerticesWithEdgesFrom(v)?.length ?? 0)
             .filter(orphan => orphan !== this.OBJECT);
         orphans.forEach(orphan => inheritance.addEdge(orphan, this.OBJECT));
 

--- a/common/src/PddlPlanParser.ts
+++ b/common/src/PddlPlanParser.ts
@@ -124,7 +124,7 @@ export class PddlPlanParser {
             this.endOfBufferToBeParsedNextTime = '';
         }
         if (this.planBuilder.getSteps().length > 0 ||
-            this.plans.length < (this.options.minimumPlansExpected || 1)) {
+            this.plans.length < (this.options.minimumPlansExpected ?? 1)) {
             this.plans.push(this.planBuilder.build(this.domain, this.problem));
             this.planBuilder = new PlanBuilder(this.options.epsilon);
         }

--- a/common/src/PddlProblemParser.ts
+++ b/common/src/PddlProblemParser.ts
@@ -163,7 +163,7 @@ export class PddlProblemParser {
             return undefined;
         }
         else if (node.getToken().tokenText === '(not') {
-            let nested = node.getFirstChild(PddlTokenType.OpenBracket, /.*/) || node.getFirstChild(PddlTokenType.OpenBracketOperator, /.*/);
+            let nested = node.getFirstChild(PddlTokenType.OpenBracket, /.*/) ?? node.getFirstChild(PddlTokenType.OpenBracketOperator, /.*/);
             if (!nested) {
                 return undefined;
             }

--- a/common/src/PddlSyntaxNode.ts
+++ b/common/src/PddlSyntaxNode.ts
@@ -278,21 +278,21 @@ export class PddlSyntaxNode extends TextRange {
 
     getPrecedingSiblings(type: PddlTokenType, centralNode?: PddlSyntaxNode): PddlSyntaxNode[] {
         let siblings = this.getSiblings(type, /.*/);
-        let centralNodeStart = (centralNode || this).getStart();
+        let centralNodeStart = (centralNode ?? this).getStart();
         let precedingSiblings = siblings.filter(sibling => sibling.getStart() < centralNodeStart);
         return precedingSiblings;
     }
 
     getFollowingSiblings(type: PddlTokenType, centralNode?: PddlSyntaxNode): PddlSyntaxNode[] {
         let siblings = this.getSiblings(type, /.*/);
-        let centralNodeStart = (centralNode || this).getStart();
+        let centralNodeStart = (centralNode ?? this).getStart();
         let followingSiblings = siblings.filter(sibling => sibling.getStart() > centralNodeStart);
         return followingSiblings;
     }
 
     private getSiblings(type: PddlTokenType, pattern: RegExp): PddlSyntaxNode[] {
         if (this.isRoot()) { return []; }
-        return this.getParent()?.getChildrenOfType(type, pattern) || [];
+        return this.getParent()?.getChildrenOfType(type, pattern) ?? [];
     }
 
     isDocument(): boolean {
@@ -342,10 +342,10 @@ export class PddlBracketNode extends PddlSyntaxNode {
     }
 
     getText(): string {
-        return super.getText() + (this.closeToken?.tokenText || '');
+        return super.getText() + (this.closeToken?.tokenText ?? '');
     }
 
     getNonCommentText(): string {
-        return super.getNonCommentText() + (this.closeToken?.tokenText || '');
+        return super.getNonCommentText() + (this.closeToken?.tokenText ?? '');
     }
 }

--- a/common/src/PddlWorkspace.ts
+++ b/common/src/PddlWorkspace.ts
@@ -309,7 +309,7 @@ export class PddlWorkspace extends EventEmitter {
         let folder = this.folders.get(PddlWorkspace.getFolderPath(domainInfo.fileUri));
 
         // find problem files in the same folder that match the domain name
-        let problemFiles = folder?.getProblemFilesFor(domainInfo) || [];
+        let problemFiles = folder?.getProblemFilesFor(domainInfo) ?? [];
 
         return problemFiles;
     }

--- a/common/src/PlanValuesParser.ts
+++ b/common/src/PlanValuesParser.ts
@@ -33,7 +33,7 @@ export class PlanValuesParser {
                 planStepFunctionValues.slice(1, 1 + functions.length));
 
             if (this.describesDurativeAction(planStepFunctionValues)) {
-                this.addState(planStep.getStartTime() + (planStep.getDuration() || 1e-3),
+                this.addState(planStep.getStartTime() + (planStep.getDuration() ?? 1e-3),
                     planStepFunctionValues.slice(1 + functions.length));
             }
         });

--- a/common/src/ProblemInfo.ts
+++ b/common/src/ProblemInfo.ts
@@ -42,7 +42,7 @@ export class ProblemInfo extends FileInfo {
     }
 
     getObjects(type: string): string[] {
-        return (this.objects.getTypeCaseInsensitive(type)?.getObjects()) || [];
+        return (this.objects.getTypeCaseInsensitive(type)?.getObjects()) ?? [];
     }
 
     getObjectsTypeMap(): TypeObjectMap {

--- a/common/src/ProblemParserPreProcessor.ts
+++ b/common/src/ProblemParserPreProcessor.ts
@@ -44,7 +44,7 @@ export class ProblemParserPreProcessor {
                         preProcessor = new PythonPreProcessor(this.context.pythonPath(), match[3], args1, match[0], match.index);
                     } catch (err) {
                         console.log(err);
-                        throw new PreProcessingError(err.message || err, 0, 0);
+                        throw new PreProcessingError(err.message ?? err, 0, 0);
                     }
                     break;
                 case "nunjucks":
@@ -52,7 +52,7 @@ export class ProblemParserPreProcessor {
                         preProcessor = new NunjucksPreProcessor(match[6], match[0], match.index, true);
                     } catch (err) {
                         console.log(err);
-                        throw new PreProcessingError(err.message || err, 0, 0);
+                        throw new PreProcessingError(err.message ?? err, 0, 0);
                     }
                     break;
                 case "jinja2":
@@ -61,7 +61,7 @@ export class ProblemParserPreProcessor {
                         preProcessor = new Jinja2PreProcessor(this.context.pythonPath(), this.context.extensionPath, match[6], match[0], match.index);
                     } catch (err) {
                         console.log(err);
-                        throw new PreProcessingError(err.message || err, 0, 0);
+                        throw new PreProcessingError(err.message ?? err, 0, 0);
                     }
                     break;
                 default:

--- a/common/test/ModelHierarchyTest.ts
+++ b/common/test/ModelHierarchyTest.ts
@@ -7,6 +7,7 @@
 import * as assert from 'assert';
 import { ModelHierarchy, VariableReferenceKind } from '../src/ModelHierarchy';
 import { createPddlDomainParser } from './PddlDomainParserTest';
+import { UnrecognizedStructure } from '../src/DomainInfo';
 
 describe('ModelHierarchy', () => {
 
@@ -33,7 +34,7 @@ describe('ModelHierarchy', () => {
             let actual = new ModelHierarchy(domainInfo).getReferenceInfo(p, pddlText.lastIndexOf('(p)') + 1);
 
             // THEN
-            assert.strictEqual(actual.structure?.getNameOrEmpty(), "a1", "action name");
+            assert.strictEqual(actual.structure.getNameOrEmpty(), "a1", "action name");
             assert.strictEqual(actual.getTimeQualifier(), "", "action time qualifier");
             assert.strictEqual(actual.kind, VariableReferenceKind.READ, "read/write kind");
             assert.strictEqual(actual.part, "condition", "part");
@@ -62,7 +63,7 @@ describe('ModelHierarchy', () => {
             let actual = new ModelHierarchy(domainInfo).getReferenceInfo(p, pddlText.lastIndexOf('(p)') + 1);
 
             // THEN
-            assert.strictEqual(actual.structure?.getNameOrEmpty(), "a1", "action name");
+            assert.strictEqual(actual.structure.getNameOrEmpty(), "a1", "action name");
             assert.strictEqual(actual.getTimeQualifier(), "", "action time qualifier");
             assert.strictEqual(actual.kind, VariableReferenceKind.WRITE, "read/write kind");
             assert.strictEqual(actual.part, "effect", "part");
@@ -91,7 +92,7 @@ describe('ModelHierarchy', () => {
             let actual = new ModelHierarchy(domainInfo).getReferenceInfo(p, pddlText.lastIndexOf('(p)') + 1);
 
             // THEN
-            assert.strictEqual(actual.structure?.getNameOrEmpty(), "a1", "action name");
+            assert.strictEqual(actual.structure.getNameOrEmpty(), "a1", "action name");
             assert.strictEqual(actual.getTimeQualifier(), "", "action time qualifier");
             assert.strictEqual(actual.kind, VariableReferenceKind.READ, "read/write kind");
             assert.strictEqual(actual.part, "condition", "part");
@@ -120,7 +121,7 @@ describe('ModelHierarchy', () => {
             let actual = new ModelHierarchy(domainInfo).getReferenceInfo(p, pddlText.lastIndexOf('(p)') + 1);
 
             // THEN
-            assert.strictEqual(actual.structure?.getNameOrEmpty(), "a1", "action name");
+            assert.strictEqual(actual.structure.getNameOrEmpty(), "a1", "action name");
             assert.strictEqual(actual.getTimeQualifier(), "", "action time qualifier");
             assert.strictEqual(actual.kind, VariableReferenceKind.WRITE, "read/write kind");
             assert.strictEqual(actual.part, "effect", "part");
@@ -149,7 +150,7 @@ describe('ModelHierarchy', () => {
             let actual = new ModelHierarchy(domainInfo).getReferenceInfo(f, pddlText.lastIndexOf('(f)') + 1);
 
             // THEN
-            assert.strictEqual(actual.structure?.getNameOrEmpty(), "a1", "action name");
+            assert.strictEqual(actual.structure.getNameOrEmpty(), "a1", "action name");
             assert.strictEqual(actual.getTimeQualifier(), "", "action time qualifier");
             assert.strictEqual(actual.kind, VariableReferenceKind.READ, "read/write kind");
             assert.strictEqual(actual.part, "condition", "part");
@@ -178,7 +179,7 @@ describe('ModelHierarchy', () => {
             let actual = new ModelHierarchy(domainInfo).getReferenceInfo(f, pddlText.lastIndexOf('(f)') + 1);
 
             // THEN
-            assert.strictEqual(actual.structure?.getNameOrEmpty(), "a1", "action name");
+            assert.strictEqual(actual.structure.getNameOrEmpty(), "a1", "action name");
             assert.strictEqual(actual.getTimeQualifier(), "", "action time qualifier");
             assert.strictEqual(actual.kind, VariableReferenceKind.WRITE, "read/write kind");
             assert.strictEqual(actual.part, "effect", "part");
@@ -208,7 +209,7 @@ describe('ModelHierarchy', () => {
             let actual = new ModelHierarchy(domainInfo).getReferenceInfo(f, pddlText.lastIndexOf('(f)') + 1);
 
             // THEN
-            assert.strictEqual(actual.structure?.getNameOrEmpty(), "a1", "action name");
+            assert.strictEqual(actual.structure.getNameOrEmpty(), "a1", "action name");
             assert.strictEqual(actual.getTimeQualifier(), "at start", "action time qualifier");
             assert.strictEqual(actual.kind, VariableReferenceKind.READ, "read/write kind");
             assert.strictEqual(actual.part, "condition", "part");
@@ -237,7 +238,7 @@ describe('ModelHierarchy', () => {
             let actual = new ModelHierarchy(domainInfo).getReferenceInfo(f, pddlText.lastIndexOf('(f)') + 1);
 
             // THEN
-            assert.strictEqual(actual.structure?.getNameOrEmpty(), "a1", "action name");
+            assert.strictEqual(actual.structure.getNameOrEmpty(), "a1", "action name");
             assert.strictEqual(actual.getTimeQualifier(), "", "action time qualifier");
             assert.strictEqual(actual.kind, VariableReferenceKind.WRITE, "read/write kind");
             assert.strictEqual(actual.part, "effect", "part");
@@ -266,7 +267,7 @@ describe('ModelHierarchy', () => {
             let actual = new ModelHierarchy(domainInfo).getReferenceInfo(f, pddlText.lastIndexOf('(f)') + 1);
 
             // THEN
-            assert.strictEqual(actual.structure?.getNameOrEmpty(), "a1", "action name");
+            assert.strictEqual(actual.structure.getNameOrEmpty(), "a1", "action name");
             assert.strictEqual(actual.getTimeQualifier(), "", "action time qualifier");
             assert.strictEqual(actual.kind, VariableReferenceKind.READ, "read/write kind");
             assert.strictEqual(actual.part, "duration", "part");
@@ -298,7 +299,7 @@ describe('ModelHierarchy', () => {
             let actual = new ModelHierarchy(domainInfo).getReferenceInfo(g, pddlText.lastIndexOf('(g)') + 1);
 
             // THEN
-            assert.strictEqual(actual.structure?.getNameOrEmpty(), "a1", "action name");
+            assert.strictEqual(actual.structure.getNameOrEmpty(), "a1", "action name");
             assert.strictEqual(actual.getTimeQualifier(), "at end", "action time qualifier");
             assert.strictEqual(actual.kind, VariableReferenceKind.READ, "read/write kind");
             assert.strictEqual(actual.part, "effect", "part");
@@ -327,7 +328,7 @@ describe('ModelHierarchy', () => {
             let actual = new ModelHierarchy(domainInfo).getReferenceInfo(p, pddlText.lastIndexOf('(p)') + 1);
 
             // THEN
-            assert.strictEqual(actual.structure?.getNameOrEmpty(), "e1", "event name");
+            assert.strictEqual(actual.structure.getNameOrEmpty(), "e1", "event name");
             assert.strictEqual(actual.getTimeQualifier(), "", "time qualifier");
             assert.strictEqual(actual.kind, VariableReferenceKind.READ, "read/write kind");
             assert.strictEqual(actual.part, "condition", "part");
@@ -356,11 +357,40 @@ describe('ModelHierarchy', () => {
             let actual = new ModelHierarchy(domainInfo).getReferenceInfo(f, pddlText.lastIndexOf('(f)') + 1);
 
             // THEN
-            assert.strictEqual(actual.structure?.getNameOrEmpty(), "p1", "process name");
+            assert.strictEqual(actual.structure.getNameOrEmpty(), "p1", "process name");
             assert.strictEqual(actual.getTimeQualifier(), "", "time qualifier");
             assert.strictEqual(actual.kind, VariableReferenceKind.WRITE, "read/write kind");
             assert.strictEqual(actual.part, "effect", "part");
             assert.strictEqual(actual.relevantCode, "(increase (f) (* #t 3.14))", "relevant code");
+        });
+
+        it('should get predicate used in constraint', () => {
+            // GIVEN
+            let pddlText = `(define (domain d)
+
+            (:predicates (p))
+            
+            (:constraints (and
+                (sometime (p))
+            ))
+            )`;
+            
+            let domainInfo = createPddlDomainParser(pddlText).getDomain();
+            
+            if (!domainInfo) { assert.fail("could not parse test PDDL"); }
+
+            const p = domainInfo?.getPredicates()[0];
+
+            // WHEN
+            let actual = new ModelHierarchy(domainInfo).getReferenceInfo(p, pddlText.lastIndexOf('(p)') + 1);
+
+            // THEN
+            assert.ok(actual);
+            assert.ok(actual.structure instanceof UnrecognizedStructure, "enclosing structure type should be UnrecognizedStructure");
+            assert.strictEqual(actual.getTimeQualifier(), "", "time qualifier");
+            assert.strictEqual(actual.kind, VariableReferenceKind.UNRECOGNIZED, "read/write kind"); // this should eventually by a READ
+            assert.strictEqual(actual.part, "", "part");
+            assert.strictEqual(actual.relevantCode, undefined, "relevant code"); // should be (sometime (p))
         });
 
     });


### PR DESCRIPTION
- Planning Domain Session generation email sending is repaired. VS Code changed behavior of the `env.openExternal(Uri)` API and prevented it from opening `mailto:` URLs.
- Updated to Typescript 3.7.3
  - Bulk replaced Typescript `||` with `??` operator where appropriate (i.e. when returning default numeric or more generally non-boolean values).
  - Simplified code by optional chaining using the `.?` Elvis operator.
- More Typescript strict semantic checking clean-up