### PR TITLE
Webpack, bugfixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 out
+dist
 node_modules
 **/*.vsix
 npm-debug.log

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -10,6 +10,7 @@
 		"davidanson.vscode-markdownlint",
 		"vscode-icons-team.vscode-icons",
 		"animu5.vscode-file-header-comment",
+		"eamodio.tsl-problem-matcher",
 	],
 	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
 	"unwantedRecommendations": [

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -20,7 +20,7 @@
 			"request": "launch",
 			"runtimeExecutable": "${execPath}",
 			"args": [
-                "--extensionDevelopmentPath=${workspaceFolder}"
+				"--extensionDevelopmentPath=${workspaceFolder}"
 			],
 			"stopOnEntry": false,
 			"sourceMaps": true,

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -20,14 +20,14 @@
 			"request": "launch",
 			"runtimeExecutable": "${execPath}",
 			"args": [
-				"--extensionDevelopmentPath=${workspaceRoot}"
+                "--extensionDevelopmentPath=${workspaceFolder}"
 			],
 			"stopOnEntry": false,
 			"sourceMaps": true,
 			"outFiles": [
-				"${workspaceRoot}/out/**/*.js"
+                "${workspaceFolder}/dist/**/*.js"
 			],
-			"preLaunchTask": "compile"
+            "preLaunchTask": "npm: webpack"
 		},
 		{
 			"name": "Integration Tests",
@@ -41,7 +41,9 @@
 				"--extensionTestsPath=${workspaceFolder}/out/test/suite/index",
 				"--disable-extensions"
 			],
-			"outFiles": ["${workspaceFolder}/out/test/**/*.js"],
+			"outFiles": [
+			    "${workspaceFolder}/out/test/**/*.js"
+			],
 			"preLaunchTask": "compile"
 		}
 	]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -25,7 +25,7 @@
 				"reveal": "never"
 			},
 			"problemMatcher": [
-				"$tsc-watch"
+				"$ts-webpack"
 			]
 		}
 	]

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -21,3 +21,4 @@ coverage/
 .github/
 downloadVisJs.js
 webpack.config.js
+node_modules

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,6 +1,6 @@
 .vscode/**
 typings/**
-out/test/**
+out/**
 test/**
 src/**
 **/*.map
@@ -8,7 +8,6 @@ src/**
 tsconfig.json
 *.cmd
 .vscode-test/**
-val/**
 .vscodeignore
 package-lock.json
 .eslintrc.js
@@ -21,3 +20,4 @@ coverage/
 .nyc_output/
 .github/
 downloadVisJs.js
+webpack.config.js

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -22,3 +22,4 @@ coverage/
 downloadVisJs.js
 webpack.config.js
 node_modules
+views/.eslintrc.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # PDDL support - What's new?
 
+## 2.17.4
+
+- Faster start-up time due to migration to Webpack. Please report any errors that fell through my week of hands-on usage/testing.
+- Fixed bug, where the test results/outcomes were not being displayed on the tree, if the tree was first-time-expanded _during_ the execution of the tests.
+- Fixed regression on the visual search debugger related to selection of nodes on the tree.
+
 ## 2.17.3
 
 Escaping spaces in VAL paths on MacOS.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pddl",
-  "version": "2.17.3",
+  "version": "2.17.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -332,6 +332,193 @@
         }
       }
     },
+    "@webassemblyjs/ast": {
+      "version": "1.9.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@webassemblyjs/ast/-/ast-1.9.0.tgz",
+      "integrity": "sha1-vYUGBLQEJFmlpBzX0zjL7Wle2WQ=",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/helper-module-context": "1.9.0",
+        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+        "@webassemblyjs/wast-parser": "1.9.0"
+      }
+    },
+    "@webassemblyjs/floating-point-hex-parser": {
+      "version": "1.9.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.9.0.tgz",
+      "integrity": "sha1-PD07Jxvd/ITesA9xNEQ4MR1S/7Q=",
+      "dev": true
+    },
+    "@webassemblyjs/helper-api-error": {
+      "version": "1.9.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@webassemblyjs/helper-api-error/-/helper-api-error-1.9.0.tgz",
+      "integrity": "sha1-ID9nbjM7lsnaLuqzzO8zxFkotqI=",
+      "dev": true
+    },
+    "@webassemblyjs/helper-buffer": {
+      "version": "1.9.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@webassemblyjs/helper-buffer/-/helper-buffer-1.9.0.tgz",
+      "integrity": "sha1-oUQtJpxf6yP8vJ73WdrDVH8p3gA=",
+      "dev": true
+    },
+    "@webassemblyjs/helper-code-frame": {
+      "version": "1.9.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.9.0.tgz",
+      "integrity": "sha1-ZH+Iks0gQ6gqwMjF51w28dkVnyc=",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/wast-printer": "1.9.0"
+      }
+    },
+    "@webassemblyjs/helper-fsm": {
+      "version": "1.9.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@webassemblyjs/helper-fsm/-/helper-fsm-1.9.0.tgz",
+      "integrity": "sha1-wFJWtxJEIUZx9LCOwQitY7cO3bg=",
+      "dev": true
+    },
+    "@webassemblyjs/helper-module-context": {
+      "version": "1.9.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@webassemblyjs/helper-module-context/-/helper-module-context-1.9.0.tgz",
+      "integrity": "sha1-JdiIS3aDmHGgimxvgGw5ee9xLwc=",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.9.0"
+      }
+    },
+    "@webassemblyjs/helper-wasm-bytecode": {
+      "version": "1.9.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.9.0.tgz",
+      "integrity": "sha1-T+2L6sm4wU+MWLcNEk1UndH+V5A=",
+      "dev": true
+    },
+    "@webassemblyjs/helper-wasm-section": {
+      "version": "1.9.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.9.0.tgz",
+      "integrity": "sha1-WkE41aYpK6GLBMWuSXF+QWeWU0Y=",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/helper-buffer": "1.9.0",
+        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+        "@webassemblyjs/wasm-gen": "1.9.0"
+      }
+    },
+    "@webassemblyjs/ieee754": {
+      "version": "1.9.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@webassemblyjs/ieee754/-/ieee754-1.9.0.tgz",
+      "integrity": "sha1-Fceg+6roP7JhQ7us9tbfFwKtOeQ=",
+      "dev": true,
+      "requires": {
+        "@xtuc/ieee754": "^1.2.0"
+      }
+    },
+    "@webassemblyjs/leb128": {
+      "version": "1.9.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@webassemblyjs/leb128/-/leb128-1.9.0.tgz",
+      "integrity": "sha1-8Zygt2ptxVYjoJz/p2noOPoeHJU=",
+      "dev": true,
+      "requires": {
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "@webassemblyjs/utf8": {
+      "version": "1.9.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@webassemblyjs/utf8/-/utf8-1.9.0.tgz",
+      "integrity": "sha1-BNM7Y2945qaBMifoJAL3Y3tiKas=",
+      "dev": true
+    },
+    "@webassemblyjs/wasm-edit": {
+      "version": "1.9.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@webassemblyjs/wasm-edit/-/wasm-edit-1.9.0.tgz",
+      "integrity": "sha1-P+bXnT8PkiGDqoYALELdJWz+6c8=",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/helper-buffer": "1.9.0",
+        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+        "@webassemblyjs/helper-wasm-section": "1.9.0",
+        "@webassemblyjs/wasm-gen": "1.9.0",
+        "@webassemblyjs/wasm-opt": "1.9.0",
+        "@webassemblyjs/wasm-parser": "1.9.0",
+        "@webassemblyjs/wast-printer": "1.9.0"
+      }
+    },
+    "@webassemblyjs/wasm-gen": {
+      "version": "1.9.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@webassemblyjs/wasm-gen/-/wasm-gen-1.9.0.tgz",
+      "integrity": "sha1-ULxw7Gje2OJ2OwGhQYv0NJGnpJw=",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+        "@webassemblyjs/ieee754": "1.9.0",
+        "@webassemblyjs/leb128": "1.9.0",
+        "@webassemblyjs/utf8": "1.9.0"
+      }
+    },
+    "@webassemblyjs/wasm-opt": {
+      "version": "1.9.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@webassemblyjs/wasm-opt/-/wasm-opt-1.9.0.tgz",
+      "integrity": "sha1-IhEYHlsxMmRDzIES658LkChyGmE=",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/helper-buffer": "1.9.0",
+        "@webassemblyjs/wasm-gen": "1.9.0",
+        "@webassemblyjs/wasm-parser": "1.9.0"
+      }
+    },
+    "@webassemblyjs/wasm-parser": {
+      "version": "1.9.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@webassemblyjs/wasm-parser/-/wasm-parser-1.9.0.tgz",
+      "integrity": "sha1-nUjkSCbfSmWYKUqmyHRp1kL/9l4=",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/helper-api-error": "1.9.0",
+        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+        "@webassemblyjs/ieee754": "1.9.0",
+        "@webassemblyjs/leb128": "1.9.0",
+        "@webassemblyjs/utf8": "1.9.0"
+      }
+    },
+    "@webassemblyjs/wast-parser": {
+      "version": "1.9.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@webassemblyjs/wast-parser/-/wast-parser-1.9.0.tgz",
+      "integrity": "sha1-MDERXXmsW9JhVWzsw/qQo+9FGRQ=",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/floating-point-hex-parser": "1.9.0",
+        "@webassemblyjs/helper-api-error": "1.9.0",
+        "@webassemblyjs/helper-code-frame": "1.9.0",
+        "@webassemblyjs/helper-fsm": "1.9.0",
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "@webassemblyjs/wast-printer": {
+      "version": "1.9.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@webassemblyjs/wast-printer/-/wast-printer-1.9.0.tgz",
+      "integrity": "sha1-STXVTIX+9jewDOn1I3dFHQDUeJk=",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/wast-parser": "1.9.0",
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "@xtuc/ieee754": {
+      "version": "1.2.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+      "integrity": "sha1-7vAUoxRa5Hehy8AM0eVSM23Ot5A=",
+      "dev": true
+    },
+    "@xtuc/long": {
+      "version": "4.2.2",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@xtuc/long/-/long-4.2.2.tgz",
+      "integrity": "sha1-0pHGpOl5ibXGHZrPOWrk/hM6cY0=",
+      "dev": true
+    },
     "a-sync-waterfall": {
       "version": "1.0.1",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz",
@@ -529,6 +716,18 @@
         "uri-js": "^4.2.2"
       }
     },
+    "ajv-errors": {
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/ajv-errors/-/ajv-errors-1.0.1.tgz",
+      "integrity": "sha1-81mGrOuRr63sQQL72FAUlQzvpk0=",
+      "dev": true
+    },
+    "ajv-keywords": {
+      "version": "3.4.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
+      "integrity": "sha1-75FuJxxkrBIXH9g4TqrmsjRYVNo=",
+      "dev": true
+    },
     "ansi-colors": {
       "version": "3.2.3",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/ansi-colors/-/ansi-colors-3.2.3.tgz",
@@ -588,6 +787,12 @@
         "diagnostic-channel-publishers": "^0.3.2"
       }
     },
+    "aproba": {
+      "version": "1.2.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha1-aALmJk79GMeQobDVF/DyYnvyyUo=",
+      "dev": true
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/argparse/-/argparse-1.0.10.tgz",
@@ -597,10 +802,34 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "arr-diff": {
+      "version": "4.0.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/arr-diff/-/arr-diff-4.0.0.tgz",
+      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+      "dev": true
+    },
+    "arr-flatten": {
+      "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
+      "dev": true
+    },
+    "arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "dev": true
+    },
     "array-flatten": {
       "version": "1.1.1",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+    },
+    "array-unique": {
+      "version": "0.3.2",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/array-unique/-/array-unique-0.3.2.tgz",
+      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+      "dev": true
     },
     "asap": {
       "version": "2.0.6",
@@ -615,6 +844,52 @@
         "safer-buffer": "~2.1.0"
       }
     },
+    "asn1.js": {
+      "version": "4.10.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/asn1.js/-/asn1.js-4.10.1.tgz",
+      "integrity": "sha1-ucK/WAXx5kqt7tbfOiv6+1pz9aA=",
+      "dev": true,
+      "requires": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.8",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/bn.js/-/bn.js-4.11.8.tgz",
+          "integrity": "sha1-LN4J617jQfSEdGuwMJsyU7GxRC8=",
+          "dev": true
+        }
+      }
+    },
+    "assert": {
+      "version": "1.5.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/assert/-/assert-1.5.0.tgz",
+      "integrity": "sha1-VcEJqvbgrv2z3EtxJAxwv1dLGOs=",
+      "dev": true,
+      "requires": {
+        "object-assign": "^4.1.1",
+        "util": "0.10.3"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.1",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/inherits/-/inherits-2.0.1.tgz",
+          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+          "dev": true
+        },
+        "util": {
+          "version": "0.10.3",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/util/-/util-0.10.3.tgz",
+          "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.1"
+          }
+        }
+      }
+    },
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -626,10 +901,22 @@
       "integrity": "sha1-5gtrDo8wG9l+U3UhW9pAbIURjAs=",
       "dev": true
     },
+    "assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "dev": true
+    },
     "astral-regex": {
       "version": "1.0.0",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/astral-regex/-/astral-regex-1.0.0.tgz",
       "integrity": "sha1-bIw/uCfdQ+45GPJ7gngqt2WKb9k=",
+      "dev": true
+    },
+    "async-each": {
+      "version": "1.0.3",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/async-each/-/async-each-1.0.3.tgz",
+      "integrity": "sha1-tyfb+H12UWAvBvTUrDh/R9kbDL8=",
       "dev": true
     },
     "async-hook-jl": {
@@ -660,6 +947,12 @@
       "version": "0.4.0",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "atob": {
+      "version": "2.1.2",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha1-bZUX654DDSQ2ZmZR6GvZ9vE1M8k=",
+      "dev": true
     },
     "await-notify": {
       "version": "1.0.1",
@@ -693,6 +986,67 @@
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
+    "base": {
+      "version": "0.11.2",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/base/-/base-0.11.2.tgz",
+      "integrity": "sha1-e95c7RRbbVUakNuH+DxVi060io8=",
+      "dev": true,
+      "requires": {
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "base64-js": {
+      "version": "1.3.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha1-WOzoy3XdB+ce0IxzarxfrE2/jfE=",
+      "dev": true
+    },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -701,11 +1055,29 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "big.js": {
+      "version": "5.2.2",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/big.js/-/big.js-5.2.2.tgz",
+      "integrity": "sha1-ZfCvOC9Xi83HQr2cKB6cstd2gyg=",
+      "dev": true
+    },
     "binary-extensions": {
       "version": "2.0.0",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/binary-extensions/-/binary-extensions-2.0.0.tgz",
       "integrity": "sha1-I8DfFPaogHf1+YbA0WfsA8PVU3w=",
       "optional": true
+    },
+    "bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha1-nyKcFb4nJFT/qXOs4NvueaGww28=",
+      "dev": true
+    },
+    "bn.js": {
+      "version": "5.1.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/bn.js/-/bn.js-5.1.1.tgz",
+      "integrity": "sha1-SO/EAxqcQEG5yZxpQdkDRjq2LrU=",
+      "dev": true
     },
     "body-parser": {
       "version": "1.19.0",
@@ -743,10 +1115,15 @@
       "version": "3.0.2",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/braces/-/braces-3.0.2.tgz",
       "integrity": "sha1-NFThpGLujVmeI23zNs2epPiv4Qc=",
-      "optional": true,
       "requires": {
         "fill-range": "^7.0.1"
       }
+    },
+    "brorand": {
+      "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
+      "dev": true
     },
     "browser-stdout": {
       "version": "1.3.1",
@@ -754,16 +1131,173 @@
       "integrity": "sha1-uqVZ7hTO1zRSIputcyZGfGH6vWA=",
       "dev": true
     },
+    "browserify-aes": {
+      "version": "1.2.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "integrity": "sha1-Mmc0ZC9APavDADIJhTu3CtQo70g=",
+      "dev": true,
+      "requires": {
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "browserify-cipher": {
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+      "integrity": "sha1-jWR0wbhwv9q807z8wZNKEOlPFfA=",
+      "dev": true,
+      "requires": {
+        "browserify-aes": "^1.0.4",
+        "browserify-des": "^1.0.0",
+        "evp_bytestokey": "^1.0.0"
+      }
+    },
+    "browserify-des": {
+      "version": "1.0.2",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/browserify-des/-/browserify-des-1.0.2.tgz",
+      "integrity": "sha1-OvTx9Zg5QDVy8cZiBDdfen9wPpw=",
+      "dev": true,
+      "requires": {
+        "cipher-base": "^1.0.1",
+        "des.js": "^1.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "browserify-rsa": {
+      "version": "4.0.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
+      "dev": true,
+      "requires": {
+        "bn.js": "^4.1.0",
+        "randombytes": "^2.0.1"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.8",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/bn.js/-/bn.js-4.11.8.tgz",
+          "integrity": "sha1-LN4J617jQfSEdGuwMJsyU7GxRC8=",
+          "dev": true
+        }
+      }
+    },
+    "browserify-sign": {
+      "version": "4.1.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/browserify-sign/-/browserify-sign-4.1.0.tgz",
+      "integrity": "sha1-T+lxs3mlrrSSXgZ3n5+h9B0knXA=",
+      "dev": true,
+      "requires": {
+        "bn.js": "^5.1.1",
+        "browserify-rsa": "^4.0.1",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "elliptic": "^6.5.2",
+        "inherits": "^2.0.4",
+        "parse-asn1": "^5.1.5",
+        "readable-stream": "^3.6.0"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
+          "dev": true
+        }
+      }
+    },
+    "browserify-zlib": {
+      "version": "0.2.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha1-KGlFnZqjviRf6P4sofRuLn9U1z8=",
+      "dev": true,
+      "requires": {
+        "pako": "~1.0.5"
+      }
+    },
+    "buffer": {
+      "version": "4.9.2",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha1-Iw6tNEACmIZEhBqwJEr4xEu+Pvg=",
+      "dev": true,
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      }
+    },
     "buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
       "dev": true
     },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8=",
+      "dev": true
+    },
+    "buffer-xor": {
+      "version": "1.0.3",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
+      "dev": true
+    },
+    "builtin-status-codes": {
+      "version": "3.0.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+      "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
+      "dev": true
+    },
     "bytes": {
       "version": "3.1.0",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/bytes/-/bytes-3.1.0.tgz",
       "integrity": "sha1-9s95M6Ng4FiPqf3oVlHNx/gF0fY="
+    },
+    "cacache": {
+      "version": "12.0.4",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/cacache/-/cacache-12.0.4.tgz",
+      "integrity": "sha1-ZovL0QWutfHZL+JVcOyVJcj6pAw=",
+      "dev": true,
+      "requires": {
+        "bluebird": "^3.5.5",
+        "chownr": "^1.1.1",
+        "figgy-pudding": "^3.5.1",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.1.15",
+        "infer-owner": "^1.0.3",
+        "lru-cache": "^5.1.1",
+        "mississippi": "^3.0.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.3",
+        "ssri": "^6.0.1",
+        "unique-filename": "^1.1.1",
+        "y18n": "^4.0.0"
+      }
+    },
+    "cache-base": {
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/cache-base/-/cache-base-1.0.1.tgz",
+      "integrity": "sha1-Cn9GQWgxyLZi7jb+TnxZ129marI=",
+      "dev": true,
+      "requires": {
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
+      }
     },
     "callsites": {
       "version": "3.1.0",
@@ -865,6 +1399,54 @@
         "readdirp": "~3.4.0"
       }
     },
+    "chownr": {
+      "version": "1.1.4",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha1-b8nXtC0ypYNZYzdmbn0ICE2izGs=",
+      "dev": true
+    },
+    "chrome-trace-event": {
+      "version": "1.0.2",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz",
+      "integrity": "sha1-I0CQ7pfH1K0aLEvq4nUF3v/GCKQ=",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.0"
+      }
+    },
+    "cipher-base": {
+      "version": "1.0.4",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/cipher-base/-/cipher-base-1.0.4.tgz",
+      "integrity": "sha1-h2Dk7MJy9MNjUy+SbYdKriwTl94=",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "class-utils": {
+      "version": "0.3.6",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/class-utils/-/class-utils-0.3.6.tgz",
+      "integrity": "sha1-+TNprouafOAv1B+q0MqDAzGQxGM=",
+      "dev": true,
+      "requires": {
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        }
+      }
+    },
     "cli-cursor": {
       "version": "3.1.0",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/cli-cursor/-/cli-cursor-3.1.0.tgz",
@@ -936,6 +1518,16 @@
         }
       }
     },
+    "collection-visit": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/collection-visit/-/collection-visit-1.0.0.tgz",
+      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "dev": true,
+      "requires": {
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
+      }
+    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/color-convert/-/color-convert-1.9.3.tgz",
@@ -964,10 +1556,72 @@
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/commander/-/commander-3.0.2.tgz",
       "integrity": "sha1-aDfD+2d62ZM9HPukLdFNURfWs54="
     },
+    "commondir": {
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+      "dev": true
+    },
+    "component-emitter": {
+      "version": "1.3.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/component-emitter/-/component-emitter-1.3.0.tgz",
+      "integrity": "sha1-FuQHD7qK4ptnnyIVhT7hgasuq8A=",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha1-kEvfGUzTEi/Gdcd/xKw9T/D9GjQ=",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
+    "console-browserify": {
+      "version": "1.2.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/console-browserify/-/console-browserify-1.2.0.tgz",
+      "integrity": "sha1-ZwY871fOts9Jk6KrOlWECujEkzY=",
+      "dev": true
+    },
+    "constants-browserify": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/constants-browserify/-/constants-browserify-1.0.0.tgz",
+      "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
+      "dev": true
     },
     "content-disposition": {
       "version": "0.5.3",
@@ -1001,10 +1655,75 @@
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
+    "copy-concurrently": {
+      "version": "1.0.5",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
+      "integrity": "sha1-kilzmMrjSTf8r9bsgTnBgFHwteA=",
+      "dev": true,
+      "requires": {
+        "aproba": "^1.1.1",
+        "fs-write-stream-atomic": "^1.0.8",
+        "iferr": "^0.1.5",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.4",
+        "run-queue": "^1.0.0"
+      }
+    },
+    "copy-descriptor": {
+      "version": "0.1.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "dev": true
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "create-ecdh": {
+      "version": "4.0.3",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/create-ecdh/-/create-ecdh-4.0.3.tgz",
+      "integrity": "sha1-yREbbzMEXEaX8UR4f5JUzcd8Rf8=",
+      "dev": true,
+      "requires": {
+        "bn.js": "^4.1.0",
+        "elliptic": "^6.0.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.8",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/bn.js/-/bn.js-4.11.8.tgz",
+          "integrity": "sha1-LN4J617jQfSEdGuwMJsyU7GxRC8=",
+          "dev": true
+        }
+      }
+    },
+    "create-hash": {
+      "version": "1.2.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/create-hash/-/create-hash-1.2.0.tgz",
+      "integrity": "sha1-iJB4rxGmN1a8+1m9IhmWvjqe8ZY=",
+      "dev": true,
+      "requires": {
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
+      }
+    },
+    "create-hmac": {
+      "version": "1.1.7",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/create-hmac/-/create-hmac-1.1.7.tgz",
+      "integrity": "sha1-aRcMeLOrlXFHsriwRXLkfq0iQ/8=",
+      "dev": true,
+      "requires": {
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      }
     },
     "cross-spawn": {
       "version": "6.0.5",
@@ -1027,6 +1746,25 @@
         }
       }
     },
+    "crypto-browserify": {
+      "version": "3.12.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+      "integrity": "sha1-OWz58xN/A+S45TLFj2mCVOAPgOw=",
+      "dev": true,
+      "requires": {
+        "browserify-cipher": "^1.0.0",
+        "browserify-sign": "^4.0.0",
+        "create-ecdh": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "^5.0.0",
+        "inherits": "^2.0.1",
+        "pbkdf2": "^3.0.3",
+        "public-encrypt": "^4.0.0",
+        "randombytes": "^2.0.0",
+        "randomfill": "^1.0.3"
+      }
+    },
     "css-select": {
       "version": "1.2.0",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/css-select/-/css-select-1.2.0.tgz",
@@ -1043,6 +1781,12 @@
       "version": "2.1.3",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/css-what/-/css-what-2.1.3.tgz",
       "integrity": "sha1-ptdgRXM2X+dGhsPzEcVlE9iChfI=",
+      "dev": true
+    },
+    "cyclist": {
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/cyclist/-/cyclist-1.0.1.tgz",
+      "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
       "dev": true
     },
     "dashdash": {
@@ -1065,6 +1809,12 @@
       "version": "1.2.0",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+    },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true
     },
     "deep-eql": {
       "version": "3.0.1",
@@ -1090,6 +1840,47 @@
         "object-keys": "^1.0.12"
       }
     },
+    "define-property": {
+      "version": "2.0.2",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/define-property/-/define-property-2.0.2.tgz",
+      "integrity": "sha1-1Flono1lS6d+AqgX+HENcCyxbp0=",
+      "dev": true,
+      "requires": {
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
+      },
+      "dependencies": {
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -1106,10 +1897,26 @@
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
     },
+    "des.js": {
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/des.js/-/des.js-1.0.1.tgz",
+      "integrity": "sha1-U4IULhvcU/hdhtU+X0qn3rkeCEM=",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
     "destroy": {
       "version": "1.0.4",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
+    "detect-file": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/detect-file/-/detect-file-1.0.0.tgz",
+      "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
+      "dev": true
     },
     "diagnostic-channel": {
       "version": "0.2.0",
@@ -1137,6 +1944,25 @@
       "integrity": "sha1-gAwN0eCov7yVg1wgKtIg/jF+WhI=",
       "dev": true
     },
+    "diffie-hellman": {
+      "version": "5.0.3",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "integrity": "sha1-QOjumPVaIUlgcUaSHGPhrl89KHU=",
+      "dev": true,
+      "requires": {
+        "bn.js": "^4.1.0",
+        "miller-rabin": "^4.0.0",
+        "randombytes": "^2.0.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.8",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/bn.js/-/bn.js-4.11.8.tgz",
+          "integrity": "sha1-LN4J617jQfSEdGuwMJsyU7GxRC8=",
+          "dev": true
+        }
+      }
+    },
     "doctrine": {
       "version": "3.0.0",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/doctrine/-/doctrine-3.0.0.tgz",
@@ -1155,6 +1981,12 @@
         "domelementtype": "^1.3.0",
         "entities": "^1.1.1"
       }
+    },
+    "domain-browser": {
+      "version": "1.2.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/domain-browser/-/domain-browser-1.2.0.tgz",
+      "integrity": "sha1-PTH1AZGmdJ3RN1p/Ui6CPULlTto=",
+      "dev": true
     },
     "domelementtype": {
       "version": "1.3.1",
@@ -1190,6 +2022,44 @@
         "mkdirp": "^0.5.0"
       }
     },
+    "duplexify": {
+      "version": "3.7.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/duplexify/-/duplexify-3.7.1.tgz",
+      "integrity": "sha1-Kk31MX9sz9kfhtb9JdjYoQO4gwk=",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -1203,6 +2073,29 @@
       "version": "1.1.1",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
+    "elliptic": {
+      "version": "6.5.2",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/elliptic/-/elliptic-6.5.2.tgz",
+      "integrity": "sha1-BcVnjXFzwEnYykM1UiJKSV0ON2I=",
+      "dev": true,
+      "requires": {
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.8",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/bn.js/-/bn.js-4.11.8.tgz",
+          "integrity": "sha1-LN4J617jQfSEdGuwMJsyU7GxRC8=",
+          "dev": true
+        }
+      }
     },
     "emitter-listener": {
       "version": "1.1.2",
@@ -1218,16 +2111,87 @@
       "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY=",
       "dev": true
     },
+    "emojis-list": {
+      "version": "3.0.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/emojis-list/-/emojis-list-3.0.0.tgz",
+      "integrity": "sha1-VXBmIEatKeLpFucariYKvf9Pang=",
+      "dev": true
+    },
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+    },
+    "end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha1-WuZKX0UFe682JuwU2gyl5LJDHrA=",
+      "dev": true,
+      "requires": {
+        "once": "^1.4.0"
+      }
+    },
+    "enhanced-resolve": {
+      "version": "4.1.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/enhanced-resolve/-/enhanced-resolve-4.1.1.tgz",
+      "integrity": "sha1-KTfiuAZs0P584JkKmPDXGjUYn2Y=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "memory-fs": "^0.5.0",
+        "tapable": "^1.0.0"
+      },
+      "dependencies": {
+        "memory-fs": {
+          "version": "0.5.0",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/memory-fs/-/memory-fs-0.5.0.tgz",
+          "integrity": "sha1-MkwBKIuIZSlm0WHbd4OHIIRajjw=",
+          "dev": true,
+          "requires": {
+            "errno": "^0.1.3",
+            "readable-stream": "^2.0.1"
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
     },
     "entities": {
       "version": "1.1.2",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/entities/-/entities-1.1.2.tgz",
       "integrity": "sha1-vfpzUplmTfr9NFKe1PhSKidf6lY=",
       "dev": true
+    },
+    "errno": {
+      "version": "0.1.7",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/errno/-/errno-0.1.7.tgz",
+      "integrity": "sha1-RoTXF3mtOa8Xfj8AeZb3xnyFJhg=",
+      "dev": true,
+      "requires": {
+        "prr": "~1.0.1"
+      }
     },
     "es-abstract": {
       "version": "1.17.5",
@@ -1479,6 +2443,75 @@
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/events/-/events-3.1.0.tgz",
       "integrity": "sha1-hCea8bNMt1qoi/X/KR9tC9mzGlk="
     },
+    "evp_bytestokey": {
+      "version": "1.0.3",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+      "integrity": "sha1-f8vbGY3HGVlDLv4ThCaE4FJaywI=",
+      "dev": true,
+      "requires": {
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "execa": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/execa/-/execa-1.0.0.tgz",
+      "integrity": "sha1-xiNqW7TfbW8V6I5/AXeYIWdJ3dg=",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^4.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      }
+    },
+    "expand-brackets": {
+      "version": "2.1.4",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+      "dev": true,
+      "requires": {
+        "debug": "^2.3.3",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "posix-character-classes": "^0.1.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "expand-tilde": {
+      "version": "2.0.2",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/expand-tilde/-/expand-tilde-2.0.2.tgz",
+      "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+      "dev": true,
+      "requires": {
+        "homedir-polyfill": "^1.0.1"
+      }
+    },
     "express": {
       "version": "4.17.1",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/express/-/express-4.17.1.tgz",
@@ -1521,6 +2554,27 @@
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/extend/-/extend-3.0.2.tgz",
       "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo="
     },
+    "extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+      "dev": true,
+      "requires": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
+    },
     "external-editor": {
       "version": "3.1.0",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/external-editor/-/external-editor-3.1.0.tgz",
@@ -1539,6 +2593,71 @@
           "dev": true,
           "requires": {
             "os-tmpdir": "~1.0.2"
+          }
+        }
+      }
+    },
+    "extglob": {
+      "version": "2.0.4",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/extglob/-/extglob-2.0.4.tgz",
+      "integrity": "sha1-rQD+TcYSqSMuhxhxHcXLWrAoVUM=",
+      "dev": true,
+      "requires": {
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "expand-brackets": "^2.1.4",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
           }
         }
       }
@@ -1573,6 +2692,12 @@
         "pend": "~1.2.0"
       }
     },
+    "figgy-pudding": {
+      "version": "3.5.2",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
+      "integrity": "sha1-tO7oFIq7Adzx0aw0Nn1Z4S+mHW4=",
+      "dev": true
+    },
     "figures": {
       "version": "3.2.0",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/figures/-/figures-3.2.0.tgz",
@@ -1595,7 +2720,6 @@
       "version": "7.0.1",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/fill-range/-/fill-range-7.0.1.tgz",
       "integrity": "sha1-GRmmp8df44ssfHflGYU12prN2kA=",
-      "optional": true,
       "requires": {
         "to-regex-range": "^5.0.1"
       }
@@ -1614,6 +2738,17 @@
         "unpipe": "~1.0.0"
       }
     },
+    "find-cache-dir": {
+      "version": "2.1.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+      "integrity": "sha1-jQ+UzRP+Q8bHwmGg2GEVypGMBfc=",
+      "dev": true,
+      "requires": {
+        "commondir": "^1.0.1",
+        "make-dir": "^2.0.0",
+        "pkg-dir": "^3.0.0"
+      }
+    },
     "find-up": {
       "version": "3.0.0",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/find-up/-/find-up-3.0.0.tgz",
@@ -1621,6 +2756,18 @@
       "dev": true,
       "requires": {
         "locate-path": "^3.0.0"
+      }
+    },
+    "findup-sync": {
+      "version": "3.0.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/findup-sync/-/findup-sync-3.0.0.tgz",
+      "integrity": "sha1-F7EI+e5RLft6XH88iyfqnhqcCNE=",
+      "dev": true,
+      "requires": {
+        "detect-file": "^1.0.0",
+        "is-glob": "^4.0.0",
+        "micromatch": "^3.0.4",
+        "resolve-dir": "^1.0.1"
       }
     },
     "flat": {
@@ -1660,6 +2807,48 @@
       "integrity": "sha1-RXWyHivO50NKqb5mL0t7X5wrUTg=",
       "dev": true
     },
+    "flush-write-stream": {
+      "version": "1.1.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
+      "integrity": "sha1-jdfYc6G6vCB9lOrQwuDkQnbr8ug=",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.3.6"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
+    "for-in": {
+      "version": "1.0.2",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "dev": true
+    },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -1680,10 +2869,93 @@
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/forwarded/-/forwarded-0.1.2.tgz",
       "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
     },
+    "fragment-cache": {
+      "version": "0.2.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+      "dev": true,
+      "requires": {
+        "map-cache": "^0.2.2"
+      }
+    },
     "fresh": {
       "version": "0.5.2",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+    },
+    "from2": {
+      "version": "2.3.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/from2/-/from2-2.3.0.tgz",
+      "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
+    "fs-write-stream-atomic": {
+      "version": "1.0.10",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
+      "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "iferr": "^0.1.5",
+        "imurmurhash": "^0.1.4",
+        "readable-stream": "1 || 2"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -1719,6 +2991,21 @@
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
     },
+    "get-stream": {
+      "version": "4.1.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/get-stream/-/get-stream-4.1.0.tgz",
+      "integrity": "sha1-wbJVV189wh1Zv8ec09K0axw6VLU=",
+      "dev": true,
+      "requires": {
+        "pump": "^3.0.0"
+      }
+    },
+    "get-value": {
+      "version": "2.0.6",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+      "dev": true
+    },
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/getpass/-/getpass-0.1.7.tgz",
@@ -1748,6 +3035,41 @@
         "is-glob": "^4.0.1"
       }
     },
+    "global-modules": {
+      "version": "2.0.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/global-modules/-/global-modules-2.0.0.tgz",
+      "integrity": "sha1-mXYFrSNF8n9RU5vqJldEISFcd4A=",
+      "dev": true,
+      "requires": {
+        "global-prefix": "^3.0.0"
+      },
+      "dependencies": {
+        "global-prefix": {
+          "version": "3.0.0",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/global-prefix/-/global-prefix-3.0.0.tgz",
+          "integrity": "sha1-/IX3MGTfafUEIfR/iD/luRO6m5c=",
+          "dev": true,
+          "requires": {
+            "ini": "^1.3.5",
+            "kind-of": "^6.0.2",
+            "which": "^1.3.1"
+          }
+        }
+      }
+    },
+    "global-prefix": {
+      "version": "1.0.2",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/global-prefix/-/global-prefix-1.0.2.tgz",
+      "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
+      "dev": true,
+      "requires": {
+        "expand-tilde": "^2.0.2",
+        "homedir-polyfill": "^1.0.1",
+        "ini": "^1.3.4",
+        "is-windows": "^1.0.1",
+        "which": "^1.2.14"
+      }
+    },
     "globals": {
       "version": "12.4.0",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/globals/-/globals-12.4.0.tgz",
@@ -1756,6 +3078,12 @@
       "requires": {
         "type-fest": "^0.8.1"
       }
+    },
+    "graceful-fs": {
+      "version": "4.2.4",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/graceful-fs/-/graceful-fs-4.2.4.tgz",
+      "integrity": "sha1-Ila94U02MpWMRl68ltxGfKB6Kfs=",
+      "dev": true
     },
     "growl": {
       "version": "1.10.5",
@@ -1798,11 +3126,124 @@
       "integrity": "sha1-n1IUdYpEGWxAbZvXbOv4HsLdMeg=",
       "dev": true
     },
+    "has-value": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/has-value/-/has-value-1.0.0.tgz",
+      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+      "dev": true,
+      "requires": {
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
+      }
+    },
+    "has-values": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/has-values/-/has-values-1.0.0.tgz",
+      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "dev": true,
+      "requires": {
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "1.1.6",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/is-buffer/-/is-buffer-1.1.6.tgz",
+          "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
+          "dev": true
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "hash-base": {
+      "version": "3.1.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/hash-base/-/hash-base-3.1.0.tgz",
+      "integrity": "sha1-VcOB2eBuHSmXqIO0o/3f5/DTrzM=",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.6.0",
+        "safe-buffer": "^5.2.0"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
+          "dev": true
+        },
+        "safe-buffer": {
+          "version": "5.2.0",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/safe-buffer/-/safe-buffer-5.2.0.tgz",
+          "integrity": "sha1-t02uxJsRSPiMZLaNSbHoFcHy9Rk=",
+          "dev": true
+        }
+      }
+    },
+    "hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha1-C6vKU46NTuSg+JiNaIZlN6ADz0I=",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
     "he": {
       "version": "1.2.0",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/he/-/he-1.2.0.tgz",
       "integrity": "sha1-hK5l+n6vsWX922FWauFLrwVmTw8=",
       "dev": true
+    },
+    "hmac-drbg": {
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+      "dev": true,
+      "requires": {
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "homedir-polyfill": {
+      "version": "1.0.3",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+      "integrity": "sha1-dDKYzvTlrz4ZQWH7rcwhUdOgWOg=",
+      "dev": true,
+      "requires": {
+        "parse-passwd": "^1.0.0"
+      }
     },
     "htmlparser2": {
       "version": "3.10.1",
@@ -1861,6 +3302,12 @@
         "sshpk": "^1.7.0"
       }
     },
+    "https-browserify": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/https-browserify/-/https-browserify-1.0.0.tgz",
+      "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
+      "dev": true
+    },
     "https-proxy-agent": {
       "version": "2.2.4",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
@@ -1896,6 +3343,18 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha1-7BaFWOlaoYH9h9N/VcMrvLZwi4Q=",
+      "dev": true
+    },
+    "iferr": {
+      "version": "0.1.5",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/iferr/-/iferr-0.1.5.tgz",
+      "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
+      "dev": true
+    },
     "ignore": {
       "version": "4.0.6",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/ignore/-/ignore-4.0.6.tgz",
@@ -1912,10 +3371,26 @@
         "resolve-from": "^4.0.0"
       }
     },
+    "import-local": {
+      "version": "2.0.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/import-local/-/import-local-2.0.0.tgz",
+      "integrity": "sha1-VQcL44pZk88Y72236WH1vuXFoJ0=",
+      "dev": true,
+      "requires": {
+        "pkg-dir": "^3.0.0",
+        "resolve-cwd": "^2.0.0"
+      }
+    },
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "infer-owner": {
+      "version": "1.0.4",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/infer-owner/-/infer-owner-1.0.4.tgz",
+      "integrity": "sha1-xM78qo5RBRwqQLos6KPScpWvlGc=",
       "dev": true
     },
     "inflight": {
@@ -1931,6 +3406,12 @@
       "version": "2.0.3",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha1-7uJfVtscnsYIXgwid4CD9Zar+Sc=",
+      "dev": true
     },
     "inquirer": {
       "version": "7.1.0",
@@ -2043,10 +3524,48 @@
         }
       }
     },
+    "interpret": {
+      "version": "1.2.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/interpret/-/interpret-1.2.0.tgz",
+      "integrity": "sha1-1QYaYiS+WOgIOYX1AU2EQ1lXYpY=",
+      "dev": true
+    },
+    "invert-kv": {
+      "version": "2.0.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/invert-kv/-/invert-kv-2.0.0.tgz",
+      "integrity": "sha1-c5P1r6Weyf9fZ6J2INEcIm4+7AI=",
+      "dev": true
+    },
     "ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha1-v/OFQ+64mEglB5/zoqjmy9RngbM="
+    },
+    "is-accessor-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "1.1.6",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/is-buffer/-/is-buffer-1.1.6.tgz",
+          "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
     },
     "is-binary-path": {
       "version": "2.1.0",
@@ -2069,16 +3588,67 @@
       "integrity": "sha1-9+RrWWiQRW23Tn9ul2yzJz0G+qs=",
       "dev": true
     },
+    "is-data-descriptor": {
+      "version": "0.1.4",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "1.1.6",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/is-buffer/-/is-buffer-1.1.6.tgz",
+          "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
     "is-date-object": {
       "version": "1.0.2",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/is-date-object/-/is-date-object-1.0.2.tgz",
       "integrity": "sha1-vac28s2P0G0yhE53Q7+nSUw7/X4=",
       "dev": true
     },
+    "is-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
+      "dev": true,
+      "requires": {
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
+          "dev": true
+        }
+      }
+    },
     "is-docker": {
       "version": "2.0.0",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/is-docker/-/is-docker-2.0.0.tgz",
       "integrity": "sha1-LLDfDnXi0GT+GGTDfN6st7Lc8ls="
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "dev": true
     },
     "is-extglob": {
       "version": "2.1.1",
@@ -2102,8 +3672,16 @@
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss=",
-      "optional": true
+      "integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss="
+    },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.1"
+      }
     },
     "is-promise": {
       "version": "2.1.0",
@@ -2120,6 +3698,12 @@
         "has": "^1.0.3"
       }
     },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
+    },
     "is-symbol": {
       "version": "1.0.3",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/is-symbol/-/is-symbol-1.0.3.tgz",
@@ -2134,15 +3718,33 @@
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha1-0YUOuXkezRjmGCzhKjDzlmNLsZ0=",
+      "dev": true
+    },
     "is-wsl": {
       "version": "2.1.1",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/is-wsl/-/is-wsl-2.1.1.tgz",
       "integrity": "sha1-ShwVLUKd89RBZpSY4khtNZbrrx0="
     },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "isobject": {
+      "version": "3.0.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
     "isstream": {
@@ -2171,6 +3773,12 @@
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
+    "json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha1-u4Z8+zRQ5pEHwTHRxRS6s9yLyqk=",
+      "dev": true
+    },
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/json-schema/-/json-schema-0.2.3.tgz",
@@ -2192,6 +3800,15 @@
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
+    "json5": {
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/json5/-/json5-1.0.1.tgz",
+      "integrity": "sha1-d5+wAYYE+oVOrL9iUhgNg1Q+Pb4=",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.0"
+      }
+    },
     "jsonc-parser": {
       "version": "2.2.1",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/jsonc-parser/-/jsonc-parser-2.2.1.tgz",
@@ -2206,6 +3823,21 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
         "verror": "1.10.0"
+      }
+    },
+    "kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha1-B8BQNKbDSfoG4k+jWqdttFgM5N0=",
+      "dev": true
+    },
+    "lcid": {
+      "version": "2.0.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/lcid/-/lcid-2.0.0.tgz",
+      "integrity": "sha1-bvXS32DlL4LrIopMNz6NHzlyU88=",
+      "dev": true,
+      "requires": {
+        "invert-kv": "^2.0.0"
       }
     },
     "leven": {
@@ -2233,6 +3865,23 @@
         "uc.micro": "^1.0.1"
       }
     },
+    "loader-runner": {
+      "version": "2.4.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/loader-runner/-/loader-runner-2.4.0.tgz",
+      "integrity": "sha1-7UcGa/5TTX6ExMe5mYwqdWB9k1c=",
+      "dev": true
+    },
+    "loader-utils": {
+      "version": "1.4.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/loader-utils/-/loader-utils-1.4.0.tgz",
+      "integrity": "sha1-xXm140yzSxp07cbB+za/o3HVphM=",
+      "dev": true,
+      "requires": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^3.0.0",
+        "json5": "^1.0.1"
+      }
+    },
     "locate-path": {
       "version": "3.0.0",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/locate-path/-/locate-path-3.0.0.tgz",
@@ -2258,6 +3907,57 @@
         "chalk": "^2.0.1"
       }
     },
+    "lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha1-HaJ+ZxAnGUdpXa9oSOhH8B2EuSA=",
+      "dev": true,
+      "requires": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "make-dir": {
+      "version": "2.1.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/make-dir/-/make-dir-2.1.0.tgz",
+      "integrity": "sha1-XwMQ4YuL6JjMBwCSlaMK5B6R5vU=",
+      "dev": true,
+      "requires": {
+        "pify": "^4.0.1",
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
+          "dev": true
+        }
+      }
+    },
+    "map-age-cleaner": {
+      "version": "0.1.3",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+      "integrity": "sha1-fVg6cwZDTAVf5HSw9FB45uG0uSo=",
+      "dev": true,
+      "requires": {
+        "p-defer": "^1.0.0"
+      }
+    },
+    "map-cache": {
+      "version": "0.2.2",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/map-cache/-/map-cache-0.2.2.tgz",
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+      "dev": true
+    },
+    "map-visit": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/map-visit/-/map-visit-1.0.0.tgz",
+      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+      "dev": true,
+      "requires": {
+        "object-visit": "^1.0.0"
+      }
+    },
     "markdown-it": {
       "version": "10.0.0",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/markdown-it/-/markdown-it-10.0.0.tgz",
@@ -2279,6 +3979,17 @@
         }
       }
     },
+    "md5.js": {
+      "version": "1.3.5",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/md5.js/-/md5.js-1.3.5.tgz",
+      "integrity": "sha1-tdB7jjIW4+J81yjXL3DR5qNCAF8=",
+      "dev": true,
+      "requires": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
     "mdurl": {
       "version": "1.0.1",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/mdurl/-/mdurl-1.0.1.tgz",
@@ -2290,6 +4001,53 @@
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
+    "mem": {
+      "version": "4.3.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/mem/-/mem-4.3.0.tgz",
+      "integrity": "sha1-Rhr0l7xK4JYIzbLmDu+2m/90QXg=",
+      "dev": true,
+      "requires": {
+        "map-age-cleaner": "^0.1.1",
+        "mimic-fn": "^2.0.0",
+        "p-is-promise": "^2.0.0"
+      }
+    },
+    "memory-fs": {
+      "version": "0.4.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/memory-fs/-/memory-fs-0.4.1.tgz",
+      "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
+      "dev": true,
+      "requires": {
+        "errno": "^0.1.3",
+        "readable-stream": "^2.0.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
@@ -2299,6 +4057,135 @@
       "version": "1.1.2",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/methods/-/methods-1.1.2.tgz",
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+    },
+    "micromatch": {
+      "version": "3.1.10",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/micromatch/-/micromatch-3.1.10.tgz",
+      "integrity": "sha1-cIWbyVyYQJUvNZoGij/En57PrCM=",
+      "dev": true,
+      "requires": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
+      },
+      "dependencies": {
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "is-buffer": {
+          "version": "1.1.6",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/is-buffer/-/is-buffer-1.1.6.tgz",
+          "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
+          "dev": true
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "dev": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          }
+        }
+      }
+    },
+    "miller-rabin": {
+      "version": "4.0.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/miller-rabin/-/miller-rabin-4.0.1.tgz",
+      "integrity": "sha1-8IA1HIZbDcViqEYpZtqlNUPHik0=",
+      "dev": true,
+      "requires": {
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.8",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/bn.js/-/bn.js-4.11.8.tgz",
+          "integrity": "sha1-LN4J617jQfSEdGuwMJsyU7GxRC8=",
+          "dev": true
+        }
+      }
     },
     "mime": {
       "version": "1.6.0",
@@ -2324,6 +4211,18 @@
       "integrity": "sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs=",
       "dev": true
     },
+    "minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha1-LhlN4ERibUoQ5/f7wAznPoPk1cc=",
+      "dev": true
+    },
+    "minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
+      "dev": true
+    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/minimatch/-/minimatch-3.0.4.tgz",
@@ -2336,6 +4235,45 @@
       "version": "1.2.5",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha1-Z9ZgFLZqaoqqDAg8X9WN9OTpdgI="
+    },
+    "mississippi": {
+      "version": "3.0.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/mississippi/-/mississippi-3.0.0.tgz",
+      "integrity": "sha1-6goykfl+C16HdrNj1fChLZTGcCI=",
+      "dev": true,
+      "requires": {
+        "concat-stream": "^1.5.0",
+        "duplexify": "^3.4.2",
+        "end-of-stream": "^1.1.0",
+        "flush-write-stream": "^1.0.0",
+        "from2": "^2.1.0",
+        "parallel-transform": "^1.1.0",
+        "pump": "^3.0.0",
+        "pumpify": "^1.3.3",
+        "stream-each": "^1.1.0",
+        "through2": "^2.0.0"
+      }
+    },
+    "mixin-deep": {
+      "version": "1.3.2",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha1-ESC0PcNZp4Xc5ltVuC4lfM9HlWY=",
+      "dev": true,
+      "requires": {
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
     },
     "mkdirp": {
       "version": "0.5.4",
@@ -2407,6 +4345,20 @@
         }
       }
     },
+    "move-concurrently": {
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/move-concurrently/-/move-concurrently-1.0.1.tgz",
+      "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
+      "dev": true,
+      "requires": {
+        "aproba": "^1.1.1",
+        "copy-concurrently": "^1.0.0",
+        "fs-write-stream-atomic": "^1.0.8",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.4",
+        "run-queue": "^1.0.3"
+      }
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/ms/-/ms-2.0.0.tgz",
@@ -2418,6 +4370,25 @@
       "integrity": "sha1-FjDEKyJR/4HiooPelqVJfqkuXg0=",
       "dev": true
     },
+    "nanomatch": {
+      "version": "1.2.13",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/nanomatch/-/nanomatch-1.2.13.tgz",
+      "integrity": "sha1-uHqKpPwN6P5r6IiVs4mD/yZb0Rk=",
+      "dev": true,
+      "requires": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "fragment-cache": "^0.2.1",
+        "is-windows": "^1.0.2",
+        "kind-of": "^6.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      }
+    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -2428,6 +4399,12 @@
       "version": "0.6.2",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/negotiator/-/negotiator-0.6.2.tgz",
       "integrity": "sha1-/qz3zPUlp3rpY0Q2pkiD/+yjRvs="
+    },
+    "neo-async": {
+      "version": "2.6.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/neo-async/-/neo-async-2.6.1.tgz",
+      "integrity": "sha1-rCetpmFn+ohJpq3dg39rGJrSCBw=",
+      "dev": true
     },
     "nice-try": {
       "version": "1.0.5",
@@ -2453,11 +4430,84 @@
         }
       }
     },
+    "node-libs-browser": {
+      "version": "2.2.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/node-libs-browser/-/node-libs-browser-2.2.1.tgz",
+      "integrity": "sha1-tk9RPRgzhiX5A0bSew0jXmMfZCU=",
+      "dev": true,
+      "requires": {
+        "assert": "^1.1.1",
+        "browserify-zlib": "^0.2.0",
+        "buffer": "^4.3.0",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "^1.0.0",
+        "crypto-browserify": "^3.11.0",
+        "domain-browser": "^1.1.1",
+        "events": "^3.0.0",
+        "https-browserify": "^1.0.0",
+        "os-browserify": "^0.3.0",
+        "path-browserify": "0.0.1",
+        "process": "^0.11.10",
+        "punycode": "^1.2.4",
+        "querystring-es3": "^0.2.0",
+        "readable-stream": "^2.3.3",
+        "stream-browserify": "^2.0.1",
+        "stream-http": "^2.7.2",
+        "string_decoder": "^1.0.0",
+        "timers-browserify": "^2.0.4",
+        "tty-browserify": "0.0.0",
+        "url": "^0.11.0",
+        "util": "^0.11.0",
+        "vm-browserify": "^1.0.1"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          },
+          "dependencies": {
+            "string_decoder": {
+              "version": "1.1.1",
+              "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/string_decoder/-/string_decoder-1.1.1.tgz",
+              "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+              "dev": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
+          }
+        }
+      }
+    },
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU=",
-      "optional": true
+      "integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU="
+    },
+    "npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "dev": true,
+      "requires": {
+        "path-key": "^2.0.0"
+      }
     },
     "nth-check": {
       "version": "1.0.2",
@@ -2484,6 +4534,49 @@
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha1-R6ewFrqmi1+g7PPe4IqFxnmsZFU="
     },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
+    "object-copy": {
+      "version": "0.1.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/object-copy/-/object-copy-0.1.0.tgz",
+      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+      "dev": true,
+      "requires": {
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "is-buffer": {
+          "version": "1.1.6",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/is-buffer/-/is-buffer-1.1.6.tgz",
+          "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
     "object-inspect": {
       "version": "1.7.0",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/object-inspect/-/object-inspect-1.7.0.tgz",
@@ -2495,6 +4588,15 @@
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha1-HEfyct8nfzsdrwYWd9nILiMixg4=",
       "dev": true
+    },
+    "object-visit": {
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/object-visit/-/object-visit-1.0.1.tgz",
+      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.0"
+      }
     },
     "object.assign": {
       "version": "4.1.0",
@@ -2516,6 +4618,15 @@
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.0-next.1"
+      }
+    },
+    "object.pick": {
+      "version": "1.3.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.1"
       }
     },
     "on-finished": {
@@ -2572,11 +4683,28 @@
       "integrity": "sha1-IIhF6J4ZOtTZcUdLk5R3NqVtE/M=",
       "dev": true
     },
+    "os-browserify": {
+      "version": "0.3.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/os-browserify/-/os-browserify-0.3.0.tgz",
+      "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
+      "dev": true
+    },
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
+    },
+    "os-locale": {
+      "version": "3.1.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/os-locale/-/os-locale-3.1.0.tgz",
+      "integrity": "sha1-qAKm7hfyTBBIOrmTVxnO9O0Wvxo=",
+      "dev": true,
+      "requires": {
+        "execa": "^1.0.0",
+        "lcid": "^2.0.0",
+        "mem": "^4.0.0"
+      }
     },
     "os-tmpdir": {
       "version": "1.0.2",
@@ -2593,6 +4721,24 @@
         "os-homedir": "^1.0.0",
         "os-tmpdir": "^1.0.0"
       }
+    },
+    "p-defer": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/p-defer/-/p-defer-1.0.0.tgz",
+      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
+      "dev": true
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true
+    },
+    "p-is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/p-is-promise/-/p-is-promise-2.1.0.tgz",
+      "integrity": "sha1-kYzrrqJIpiz3/6uOO8qMX4gvxC4=",
+      "dev": true
     },
     "p-limit": {
       "version": "2.2.2",
@@ -2616,6 +4762,49 @@
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY="
     },
+    "pako": {
+      "version": "1.0.11",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha1-bJWZ00DVTf05RjgCUqNXBaa5kr8=",
+      "dev": true
+    },
+    "parallel-transform": {
+      "version": "1.2.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/parallel-transform/-/parallel-transform-1.2.0.tgz",
+      "integrity": "sha1-kEnKN9bLIYLDsdLHIL6U0UpYFPw=",
+      "dev": true,
+      "requires": {
+        "cyclist": "^1.0.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.1.5"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/parent-module/-/parent-module-1.0.1.tgz",
@@ -2624,6 +4813,26 @@
       "requires": {
         "callsites": "^3.0.0"
       }
+    },
+    "parse-asn1": {
+      "version": "5.1.5",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/parse-asn1/-/parse-asn1-5.1.5.tgz",
+      "integrity": "sha1-ADJxND2ljclMrOSU+u89IUfs6g4=",
+      "dev": true,
+      "requires": {
+        "asn1.js": "^4.0.0",
+        "browserify-aes": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.0",
+        "pbkdf2": "^3.0.3",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "parse-passwd": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/parse-passwd/-/parse-passwd-1.0.0.tgz",
+      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
+      "dev": true
     },
     "parse-semver": {
       "version": "1.1.1",
@@ -2661,6 +4870,24 @@
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha1-naGee+6NEt/wUT7Vt2lXeTvC6NQ="
     },
+    "pascalcase": {
+      "version": "0.1.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/pascalcase/-/pascalcase-0.1.1.tgz",
+      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+      "dev": true
+    },
+    "path-browserify": {
+      "version": "0.0.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/path-browserify/-/path-browserify-0.0.1.tgz",
+      "integrity": "sha1-5sTd1+06onxoogzE5Q4aTug7vEo=",
+      "dev": true
+    },
+    "path-dirname": {
+      "version": "1.0.2",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/path-dirname/-/path-dirname-1.0.2.tgz",
+      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+      "dev": true
+    },
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/path-exists/-/path-exists-3.0.0.tgz",
@@ -2689,6 +4916,19 @@
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
       "dev": true
     },
+    "pbkdf2": {
+      "version": "3.0.17",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/pbkdf2/-/pbkdf2-3.0.17.tgz",
+      "integrity": "sha1-l2wgZTBhexTrsyEUI597CTNuk6Y=",
+      "dev": true,
+      "requires": {
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      }
+    },
     "pddl-workspace": {
       "version": "3.1.0",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/pddl-workspace/-/pddl-workspace-3.1.0.tgz",
@@ -2715,8 +4955,28 @@
     "picomatch": {
       "version": "2.2.2",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/picomatch/-/picomatch-2.2.2.tgz",
-      "integrity": "sha1-IfMz6ba46v8CRo9RRupAbTRfTa0=",
-      "optional": true
+      "integrity": "sha1-IfMz6ba46v8CRo9RRupAbTRfTa0="
+    },
+    "pify": {
+      "version": "4.0.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE=",
+      "dev": true
+    },
+    "pkg-dir": {
+      "version": "3.0.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/pkg-dir/-/pkg-dir-3.0.0.tgz",
+      "integrity": "sha1-J0kCDyOe2ZCIGx9xIQ1R62UjvqM=",
+      "dev": true,
+      "requires": {
+        "find-up": "^3.0.0"
+      }
+    },
+    "posix-character-classes": {
+      "version": "0.1.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+      "dev": true
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -2724,10 +4984,28 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
+    "process": {
+      "version": "0.11.10",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/process/-/process-0.11.10.tgz",
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
+      "dev": true
+    },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I=",
+      "dev": true
+    },
     "progress": {
       "version": "2.0.3",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/progress/-/progress-2.0.3.tgz",
       "integrity": "sha1-foz42PW48jnBvGi+tOt4Vn1XLvg=",
+      "dev": true
+    },
+    "promise-inflight": {
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/promise-inflight/-/promise-inflight-1.0.1.tgz",
+      "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
       "dev": true
     },
     "proxy-addr": {
@@ -2739,10 +5017,71 @@
         "ipaddr.js": "1.9.1"
       }
     },
+    "prr": {
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/prr/-/prr-1.0.1.tgz",
+      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
+      "dev": true
+    },
     "psl": {
       "version": "1.8.0",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/psl/-/psl-1.8.0.tgz",
       "integrity": "sha1-kyb4vPsBOtzABf3/BWrM4CDlHCQ="
+    },
+    "public-encrypt": {
+      "version": "4.0.3",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/public-encrypt/-/public-encrypt-4.0.3.tgz",
+      "integrity": "sha1-T8ydd6B+SLp1J+fL4N4z0HATMeA=",
+      "dev": true,
+      "requires": {
+        "bn.js": "^4.1.0",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^5.0.0",
+        "randombytes": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.8",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/bn.js/-/bn.js-4.11.8.tgz",
+          "integrity": "sha1-LN4J617jQfSEdGuwMJsyU7GxRC8=",
+          "dev": true
+        }
+      }
+    },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha1-tKIRaBW94vTh6mAjVOjHVWUQemQ=",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "pumpify": {
+      "version": "1.5.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/pumpify/-/pumpify-1.5.1.tgz",
+      "integrity": "sha1-NlE74karJ1cLGjdKXOJ4v9dDcM4=",
+      "dev": true,
+      "requires": {
+        "duplexify": "^3.6.0",
+        "inherits": "^2.0.3",
+        "pump": "^2.0.0"
+      },
+      "dependencies": {
+        "pump": {
+          "version": "2.0.1",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/pump/-/pump-2.0.1.tgz",
+          "integrity": "sha1-Ejma3W5M91Jtlzy8i1zi4pCLOQk=",
+          "dev": true,
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        }
+      }
     },
     "punycode": {
       "version": "2.1.1",
@@ -2753,6 +5092,37 @@
       "version": "6.7.0",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/qs/-/qs-6.7.0.tgz",
       "integrity": "sha1-QdwaAV49WB8WIXdr4xr7KHapsbw="
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "dev": true
+    },
+    "querystring-es3": {
+      "version": "0.2.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/querystring-es3/-/querystring-es3-0.2.1.tgz",
+      "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
+      "dev": true
+    },
+    "randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha1-32+ENy8CcNxlzfYpE0mrekc9Tyo=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "randomfill": {
+      "version": "1.0.4",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/randomfill/-/randomfill-1.0.4.tgz",
+      "integrity": "sha1-ySGW/IarQr6YPxvzF3giSTHWFFg=",
+      "dev": true,
+      "requires": {
+        "randombytes": "^2.0.5",
+        "safe-buffer": "^5.1.0"
+      }
     },
     "range-parser": {
       "version": "1.2.1",
@@ -2799,10 +5169,38 @@
         "picomatch": "^2.2.1"
       }
     },
+    "regex-not": {
+      "version": "1.0.2",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/regex-not/-/regex-not-1.0.2.tgz",
+      "integrity": "sha1-H07OJ+ALC2XgJHpoEOaoXYOldSw=",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
+      }
+    },
     "regexpp": {
       "version": "3.1.0",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/regexpp/-/regexpp-3.1.0.tgz",
       "integrity": "sha1-IG0K0KVkjP+9uK5GQ489xRyfeOI=",
+      "dev": true
+    },
+    "remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "dev": true
+    },
+    "repeat-element": {
+      "version": "1.1.3",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/repeat-element/-/repeat-element-1.1.3.tgz",
+      "integrity": "sha1-eC4NglwMWjuzlzH4Tv7mt0Lmsc4=",
+      "dev": true
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "dev": true
     },
     "request": {
@@ -2849,10 +5247,56 @@
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha1-0LMp7MfMD2Fkn2IhW+aa9UqomJs="
     },
+    "resolve-cwd": {
+      "version": "2.0.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
+      "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
+      "dev": true,
+      "requires": {
+        "resolve-from": "^3.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "3.0.0",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/resolve-from/-/resolve-from-3.0.0.tgz",
+          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+          "dev": true
+        }
+      }
+    },
+    "resolve-dir": {
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/resolve-dir/-/resolve-dir-1.0.1.tgz",
+      "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
+      "dev": true,
+      "requires": {
+        "expand-tilde": "^2.0.0",
+        "global-modules": "^1.0.0"
+      },
+      "dependencies": {
+        "global-modules": {
+          "version": "1.0.0",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/global-modules/-/global-modules-1.0.0.tgz",
+          "integrity": "sha1-bXcPDrUjrHgWTXK15xqIdyZcw+o=",
+          "dev": true,
+          "requires": {
+            "global-prefix": "^1.0.1",
+            "is-windows": "^1.0.1",
+            "resolve-dir": "^1.0.0"
+          }
+        }
+      }
+    },
     "resolve-from": {
       "version": "4.0.0",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha1-SrzYUq0y3Xuqv+m0DgCjbbXzkuY=",
+      "dev": true
+    },
+    "resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
     },
     "restore-cursor": {
@@ -2865,12 +5309,28 @@
         "signal-exit": "^3.0.2"
       }
     },
+    "ret": {
+      "version": "0.1.15",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha1-uKSCXVvbH8P29Twrwz+BOIaBx7w=",
+      "dev": true
+    },
     "rimraf": {
       "version": "2.7.1",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/rimraf/-/rimraf-2.7.1.tgz",
       "integrity": "sha1-NXl/E6f9rcVmFCwp1PB8ytSD4+w=",
       "requires": {
         "glob": "^7.1.3"
+      }
+    },
+    "ripemd160": {
+      "version": "2.0.2",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/ripemd160/-/ripemd160-2.0.2.tgz",
+      "integrity": "sha1-ocGm9iR1FXe6XQeRTLyShQWFiQw=",
+      "dev": true,
+      "requires": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "run-async": {
@@ -2880,6 +5340,15 @@
       "dev": true,
       "requires": {
         "is-promise": "^2.1.0"
+      }
+    },
+    "run-queue": {
+      "version": "1.0.3",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/run-queue/-/run-queue-1.0.3.tgz",
+      "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
+      "dev": true,
+      "requires": {
+        "aproba": "^1.1.1"
       }
     },
     "rxjs": {
@@ -2896,6 +5365,15 @@
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
     },
+    "safe-regex": {
+      "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/safe-regex/-/safe-regex-1.1.0.tgz",
+      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "dev": true,
+      "requires": {
+        "ret": "~0.1.10"
+      }
+    },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -2905,6 +5383,17 @@
       "version": "1.2.4",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/sax/-/sax-1.2.4.tgz",
       "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk="
+    },
+    "schema-utils": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/schema-utils/-/schema-utils-1.0.0.tgz",
+      "integrity": "sha1-C3mpMgTXtgDUsoUNH2bCo0lRx3A=",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.1.0",
+        "ajv-errors": "^1.0.0",
+        "ajv-keywords": "^3.1.0"
+      }
     },
     "semver": {
       "version": "7.1.3",
@@ -2938,6 +5427,12 @@
         }
       }
     },
+    "serialize-javascript": {
+      "version": "2.1.2",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
+      "integrity": "sha1-7OxTsOAxe9yV73arcHS3OEeF+mE=",
+      "dev": true
+    },
     "serve-static": {
       "version": "1.14.1",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/serve-static/-/serve-static-1.14.1.tgz",
@@ -2954,10 +5449,49 @@
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
+    "set-value": {
+      "version": "2.0.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha1-oY1AUw5vB95CKMfe/kInr4ytAFs=",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+      "dev": true
+    },
     "setprototypeof": {
       "version": "1.1.1",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/setprototypeof/-/setprototypeof-1.1.1.tgz",
       "integrity": "sha1-fpWsskqpL1iF4KvvW6ExMw1K5oM="
+    },
+    "sha.js": {
+      "version": "2.4.11",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/sha.js/-/sha.js-2.4.11.tgz",
+      "integrity": "sha1-N6XPC4HsvGlD3hCbopYNGyZYSuc=",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -2996,6 +5530,177 @@
         "is-fullwidth-code-point": "^2.0.0"
       }
     },
+    "snapdragon": {
+      "version": "0.8.2",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/snapdragon/-/snapdragon-0.8.2.tgz",
+      "integrity": "sha1-ZJIufFZbDhQgS6GqfWlkJ40lGC0=",
+      "dev": true,
+      "requires": {
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "snapdragon-node": {
+      "version": "2.1.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "integrity": "sha1-bBdfhv8UvbByRWPo88GwIaKGhTs=",
+      "dev": true,
+      "requires": {
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "snapdragon-util": {
+      "version": "3.0.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "integrity": "sha1-+VZHlIbyrNeXAGk/b3uAXkWrVuI=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.2.0"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "1.1.6",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/is-buffer/-/is-buffer-1.1.6.tgz",
+          "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "source-list-map": {
+      "version": "2.0.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/source-list-map/-/source-list-map-2.0.1.tgz",
+      "integrity": "sha1-OZO9hzv8SEecyp6jpUeDXHwVSzQ=",
+      "dev": true
+    },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true
+    },
+    "source-map-resolve": {
+      "version": "0.5.3",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
+      "integrity": "sha1-GQhmvs51U+H48mei7oLGBrVQmho=",
+      "dev": true,
+      "requires": {
+        "atob": "^2.1.2",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
+      }
+    },
+    "source-map-support": {
+      "version": "0.5.19",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/source-map-support/-/source-map-support-0.5.19.tgz",
+      "integrity": "sha1-qYti+G3K9PZzmWSMCFKRq56P7WE=",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true
+        }
+      }
+    },
+    "source-map-url": {
+      "version": "0.4.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/source-map-url/-/source-map-url-0.4.0.tgz",
+      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+      "dev": true
+    },
+    "split-string": {
+      "version": "3.1.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha1-fLCd2jqGWFcFxks5pkZgOGguj+I=",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^3.0.0"
+      }
+    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -3018,15 +5723,136 @@
         "tweetnacl": "~0.14.0"
       }
     },
+    "ssri": {
+      "version": "6.0.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/ssri/-/ssri-6.0.1.tgz",
+      "integrity": "sha1-KjxBso3UW2K2Nnbst0ABJlrp7dg=",
+      "dev": true,
+      "requires": {
+        "figgy-pudding": "^3.5.1"
+      }
+    },
     "stack-chain": {
       "version": "1.3.7",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/stack-chain/-/stack-chain-1.3.7.tgz",
       "integrity": "sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU="
     },
+    "static-extend": {
+      "version": "0.1.2",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/static-extend/-/static-extend-0.1.2.tgz",
+      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "dev": true,
+      "requires": {
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        }
+      }
+    },
     "statuses": {
       "version": "1.5.0",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+    },
+    "stream-browserify": {
+      "version": "2.0.2",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/stream-browserify/-/stream-browserify-2.0.2.tgz",
+      "integrity": "sha1-h1IdOKRKp+6RzhzSpH3wy0ndZgs=",
+      "dev": true,
+      "requires": {
+        "inherits": "~2.0.1",
+        "readable-stream": "^2.0.2"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
+    "stream-each": {
+      "version": "1.2.3",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/stream-each/-/stream-each-1.2.3.tgz",
+      "integrity": "sha1-6+J6DDibBPvMIzZClS4Qcxr6m64=",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "stream-shift": "^1.0.0"
+      }
+    },
+    "stream-http": {
+      "version": "2.8.3",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/stream-http/-/stream-http-2.8.3.tgz",
+      "integrity": "sha1-stJCRpKIpaJ+xP6JM6z2I95lFPw=",
+      "dev": true,
+      "requires": {
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.3.6",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
+    "stream-shift": {
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha1-1wiCgVWasneEJCebCHfaPDktWj0=",
+      "dev": true
     },
     "string-width": {
       "version": "2.1.1",
@@ -3084,6 +5910,12 @@
         "ansi-regex": "^3.0.0"
       }
     },
+    "strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true
+    },
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
@@ -3139,6 +5971,68 @@
         }
       }
     },
+    "tapable": {
+      "version": "1.1.3",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/tapable/-/tapable-1.1.3.tgz",
+      "integrity": "sha1-ofzMBrWNth/XpF2i2kT186Pme6I=",
+      "dev": true
+    },
+    "terser": {
+      "version": "4.6.13",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/terser/-/terser-4.6.13.tgz",
+      "integrity": "sha1-6HmnNkpeDbUrpIkezeAHQixWqRY=",
+      "dev": true,
+      "requires": {
+        "commander": "^2.20.0",
+        "source-map": "~0.6.1",
+        "source-map-support": "~0.5.12"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha1-/UhehMA+tIgcIHIrpIA16FMa6zM=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true
+        }
+      }
+    },
+    "terser-webpack-plugin": {
+      "version": "1.4.3",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz",
+      "integrity": "sha1-Xsry29xfuZdF/QZ5H0b8ndscmnw=",
+      "dev": true,
+      "requires": {
+        "cacache": "^12.0.2",
+        "find-cache-dir": "^2.1.0",
+        "is-wsl": "^1.1.0",
+        "schema-utils": "^1.0.0",
+        "serialize-javascript": "^2.1.2",
+        "source-map": "^0.6.1",
+        "terser": "^4.1.2",
+        "webpack-sources": "^1.4.0",
+        "worker-farm": "^1.7.0"
+      },
+      "dependencies": {
+        "is-wsl": {
+          "version": "1.1.0",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/is-wsl/-/is-wsl-1.1.0.tgz",
+          "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true
+        }
+      }
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/text-table/-/text-table-0.2.0.tgz",
@@ -3150,6 +6044,51 @@
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
+    },
+    "through2": {
+      "version": "2.0.5",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha1-AcHjnrMdB8t9A6lqcIIyYLIxMs0=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
+    "timers-browserify": {
+      "version": "2.0.11",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/timers-browserify/-/timers-browserify-2.0.11.tgz",
+      "integrity": "sha1-gAsfPu4nLlvFPuRloE0OgEwxIR8=",
+      "dev": true,
+      "requires": {
+        "setimmediate": "^1.0.4"
+      }
     },
     "tmp": {
       "version": "0.1.0",
@@ -3167,11 +6106,54 @@
         "tmp": "0.1.0"
       }
     },
+    "to-arraybuffer": {
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
+      "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
+      "dev": true
+    },
+    "to-object-path": {
+      "version": "0.3.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/to-object-path/-/to-object-path-0.3.0.tgz",
+      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "1.1.6",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/is-buffer/-/is-buffer-1.1.6.tgz",
+          "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "to-regex": {
+      "version": "3.0.2",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/to-regex/-/to-regex-3.0.2.tgz",
+      "integrity": "sha1-E8/dmzNlUvMLUfM6iuG0Knp1mc4=",
+      "dev": true,
+      "requires": {
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
+      }
+    },
     "to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha1-FkjESq58jZiKMmAY7XL1tN0DkuQ=",
-      "optional": true,
       "requires": {
         "is-number": "^7.0.0"
       }
@@ -3195,10 +6177,47 @@
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/tree-kill/-/tree-kill-1.2.2.tgz",
       "integrity": "sha1-TKCakJLIi3OnzcXooBtQeweQoMw="
     },
+    "ts-loader": {
+      "version": "7.0.3",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/ts-loader/-/ts-loader-7.0.3.tgz",
+      "integrity": "sha1-G6Bv09rmEuz4uVL4kUX5rHSJgF8=",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.3.0",
+        "enhanced-resolve": "^4.0.0",
+        "loader-utils": "^1.0.2",
+        "micromatch": "^4.0.0",
+        "semver": "^6.0.0"
+      },
+      "dependencies": {
+        "micromatch": {
+          "version": "4.0.2",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha1-T8sJmb+fvC/L3SEvbWKbmlbDklk=",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
+          "dev": true
+        }
+      }
+    },
     "tslib": {
       "version": "1.11.1",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/tslib/-/tslib-1.11.1.tgz",
       "integrity": "sha1-6xXRKIJ/vuKEFUnhcfRe0zisfjU=",
+      "dev": true
+    },
+    "tty-browserify": {
+      "version": "0.0.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/tty-browserify/-/tty-browserify-0.0.0.tgz",
+      "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
       "dev": true
     },
     "tunnel": {
@@ -3260,6 +6279,12 @@
         "underscore": "1.8.3"
       }
     },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
     "typescript": {
       "version": "3.8.3",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/typescript/-/typescript-3.8.3.tgz",
@@ -3278,10 +6303,86 @@
       "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
       "dev": true
     },
+    "union-value": {
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha1-C2/nuDWuzaYcbqTU8CwUIh4QmEc=",
+      "dev": true,
+      "requires": {
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^2.0.1"
+      }
+    },
+    "unique-filename": {
+      "version": "1.1.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/unique-filename/-/unique-filename-1.1.1.tgz",
+      "integrity": "sha1-HWl2k2mtoFgxA6HmrodoG1ZXMjA=",
+      "dev": true,
+      "requires": {
+        "unique-slug": "^2.0.0"
+      }
+    },
+    "unique-slug": {
+      "version": "2.0.2",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/unique-slug/-/unique-slug-2.0.2.tgz",
+      "integrity": "sha1-uqvOkQg/xk6UWw861hPiZPfNTmw=",
+      "dev": true,
+      "requires": {
+        "imurmurhash": "^0.1.4"
+      }
+    },
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+    },
+    "unset-value": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/unset-value/-/unset-value-1.0.0.tgz",
+      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "dev": true,
+      "requires": {
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
+      },
+      "dependencies": {
+        "has-value": {
+          "version": "0.3.1",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/has-value/-/has-value-0.3.1.tgz",
+          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+          "dev": true,
+          "requires": {
+            "get-value": "^2.0.3",
+            "has-values": "^0.1.4",
+            "isobject": "^2.0.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "2.1.0",
+              "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/isobject/-/isobject-2.1.0.tgz",
+              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "dev": true,
+              "requires": {
+                "isarray": "1.0.0"
+              }
+            }
+          }
+        },
+        "has-values": {
+          "version": "0.1.4",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/has-values/-/has-values-0.1.4.tgz",
+          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+          "dev": true
+        }
+      }
+    },
+    "upath": {
+      "version": "1.2.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/upath/-/upath-1.2.0.tgz",
+      "integrity": "sha1-j2bbzVWog6za5ECK+LA1pQRMGJQ=",
+      "dev": true
     },
     "uri-js": {
       "version": "4.2.2",
@@ -3291,11 +6392,50 @@
         "punycode": "^2.1.0"
       }
     },
+    "urix": {
+      "version": "0.1.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+      "dev": true
+    },
+    "url": {
+      "version": "0.11.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/url/-/url-0.11.0.tgz",
+      "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+      "dev": true,
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+          "dev": true
+        }
+      }
+    },
     "url-join": {
       "version": "1.1.0",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/url-join/-/url-join-1.1.0.tgz",
       "integrity": "sha1-dBxsL0WWxIMNZxhGCSDQySIC3Hg=",
       "dev": true
+    },
+    "use": {
+      "version": "3.1.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/use/-/use-3.1.1.tgz",
+      "integrity": "sha1-1QyMrHmhn7wg8pEfVuuXP04QBw8=",
+      "dev": true
+    },
+    "util": {
+      "version": "0.11.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/util/-/util-0.11.1.tgz",
+      "integrity": "sha1-MjZzNyDsZLsn9uJvQhqqLhtYjWE=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3"
+      }
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -3333,6 +6473,12 @@
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
       }
+    },
+    "vm-browserify": {
+      "version": "1.1.2",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/vm-browserify/-/vm-browserify-1.1.2.tgz",
+      "integrity": "sha1-eGQcSIuObKkadfUR56OzKobl3aA=",
+      "dev": true
     },
     "vsce": {
       "version": "1.75.0",
@@ -3432,6 +6578,387 @@
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/vscode-uri/-/vscode-uri-2.1.1.tgz",
       "integrity": "sha1-WqGAM5G2690X0Ef1E2XPYsOPbpA="
     },
+    "watchpack": {
+      "version": "1.6.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/watchpack/-/watchpack-1.6.1.tgz",
+      "integrity": "sha1-KA2gqHGFkhdAEMB4x1hadM2M0OI=",
+      "dev": true,
+      "requires": {
+        "chokidar": "^2.1.8",
+        "graceful-fs": "^4.1.2",
+        "neo-async": "^2.5.0"
+      },
+      "dependencies": {
+        "anymatch": {
+          "version": "2.0.0",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/anymatch/-/anymatch-2.0.0.tgz",
+          "integrity": "sha1-vLJLTzeTTZqnrBe0ra+J58du8us=",
+          "dev": true,
+          "requires": {
+            "micromatch": "^3.1.4",
+            "normalize-path": "^2.1.1"
+          },
+          "dependencies": {
+            "normalize-path": {
+              "version": "2.1.1",
+              "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/normalize-path/-/normalize-path-2.1.1.tgz",
+              "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+              "dev": true,
+              "requires": {
+                "remove-trailing-separator": "^1.0.1"
+              }
+            }
+          }
+        },
+        "binary-extensions": {
+          "version": "1.13.1",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/binary-extensions/-/binary-extensions-1.13.1.tgz",
+          "integrity": "sha1-WYr+VHVbKGilMw0q/51Ou1Mgm2U=",
+          "dev": true
+        },
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          }
+        },
+        "chokidar": {
+          "version": "2.1.8",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/chokidar/-/chokidar-2.1.8.tgz",
+          "integrity": "sha1-gEs6e2qZNYw8XGHnHYco8EHP+Rc=",
+          "dev": true,
+          "requires": {
+            "anymatch": "^2.0.0",
+            "async-each": "^1.0.1",
+            "braces": "^2.3.2",
+            "fsevents": "^1.2.7",
+            "glob-parent": "^3.1.0",
+            "inherits": "^2.0.3",
+            "is-binary-path": "^1.0.0",
+            "is-glob": "^4.0.0",
+            "normalize-path": "^3.0.0",
+            "path-is-absolute": "^1.0.0",
+            "readdirp": "^2.2.1",
+            "upath": "^1.1.1"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          }
+        },
+        "fsevents": {
+          "version": "1.2.13",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/fsevents/-/fsevents-1.2.13.tgz",
+          "integrity": "sha1-8yXLBFVZJCi88Rs4M3DvcOO/zDg=",
+          "dev": true,
+          "optional": true
+        },
+        "glob-parent": {
+          "version": "3.1.0",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/glob-parent/-/glob-parent-3.1.0.tgz",
+          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+          "dev": true,
+          "requires": {
+            "is-glob": "^3.1.0",
+            "path-dirname": "^1.0.0"
+          },
+          "dependencies": {
+            "is-glob": {
+              "version": "3.1.0",
+              "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/is-glob/-/is-glob-3.1.0.tgz",
+              "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+              "dev": true,
+              "requires": {
+                "is-extglob": "^2.1.0"
+              }
+            }
+          }
+        },
+        "is-binary-path": {
+          "version": "1.0.1",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/is-binary-path/-/is-binary-path-1.0.1.tgz",
+          "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+          "dev": true,
+          "requires": {
+            "binary-extensions": "^1.0.0"
+          }
+        },
+        "is-buffer": {
+          "version": "1.1.6",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/is-buffer/-/is-buffer-1.1.6.tgz",
+          "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
+          "dev": true
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "readdirp": {
+          "version": "2.2.1",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/readdirp/-/readdirp-2.2.1.tgz",
+          "integrity": "sha1-DodiKjMlqjPokihcr4tOhGUppSU=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "micromatch": "^3.1.10",
+            "readable-stream": "^2.0.2"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "dev": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          }
+        }
+      }
+    },
+    "webpack": {
+      "version": "4.43.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/webpack/-/webpack-4.43.0.tgz",
+      "integrity": "sha1-xIVHsR1WMiTFYdrRFyyKoLimeOY=",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/helper-module-context": "1.9.0",
+        "@webassemblyjs/wasm-edit": "1.9.0",
+        "@webassemblyjs/wasm-parser": "1.9.0",
+        "acorn": "^6.4.1",
+        "ajv": "^6.10.2",
+        "ajv-keywords": "^3.4.1",
+        "chrome-trace-event": "^1.0.2",
+        "enhanced-resolve": "^4.1.0",
+        "eslint-scope": "^4.0.3",
+        "json-parse-better-errors": "^1.0.2",
+        "loader-runner": "^2.4.0",
+        "loader-utils": "^1.2.3",
+        "memory-fs": "^0.4.1",
+        "micromatch": "^3.1.10",
+        "mkdirp": "^0.5.3",
+        "neo-async": "^2.6.1",
+        "node-libs-browser": "^2.2.1",
+        "schema-utils": "^1.0.0",
+        "tapable": "^1.1.3",
+        "terser-webpack-plugin": "^1.4.3",
+        "watchpack": "^1.6.1",
+        "webpack-sources": "^1.4.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "6.4.1",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/acorn/-/acorn-6.4.1.tgz",
+          "integrity": "sha1-Ux5Yuj9RudrLmmZGyk3r9bFMpHQ=",
+          "dev": true
+        },
+        "eslint-scope": {
+          "version": "4.0.3",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/eslint-scope/-/eslint-scope-4.0.3.tgz",
+          "integrity": "sha1-ygODMxD2iJoyZHgaqC5j65z+eEg=",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        }
+      }
+    },
+    "webpack-cli": {
+      "version": "3.3.11",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/webpack-cli/-/webpack-cli-3.3.11.tgz",
+      "integrity": "sha1-O/IYib9Ze12Cw48hUTWkEe39xjE=",
+      "dev": true,
+      "requires": {
+        "chalk": "2.4.2",
+        "cross-spawn": "6.0.5",
+        "enhanced-resolve": "4.1.0",
+        "findup-sync": "3.0.0",
+        "global-modules": "2.0.0",
+        "import-local": "2.0.0",
+        "interpret": "1.2.0",
+        "loader-utils": "1.2.3",
+        "supports-color": "6.1.0",
+        "v8-compile-cache": "2.0.3",
+        "yargs": "13.2.4"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
+          "dev": true
+        },
+        "emojis-list": {
+          "version": "2.1.0",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/emojis-list/-/emojis-list-2.1.0.tgz",
+          "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
+          "dev": true
+        },
+        "enhanced-resolve": {
+          "version": "4.1.0",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/enhanced-resolve/-/enhanced-resolve-4.1.0.tgz",
+          "integrity": "sha1-Qcfgv9/nSsH/4eV61qXGyfN0Kn8=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "memory-fs": "^0.4.0",
+            "tapable": "^1.0.0"
+          }
+        },
+        "loader-utils": {
+          "version": "1.2.3",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/loader-utils/-/loader-utils-1.2.3.tgz",
+          "integrity": "sha1-H/XcaRHJ8KBiUxpMBLYJQGEIwsc=",
+          "dev": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^2.0.0",
+            "json5": "^1.0.1"
+          }
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "v8-compile-cache": {
+          "version": "2.0.3",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/v8-compile-cache/-/v8-compile-cache-2.0.3.tgz",
+          "integrity": "sha1-APdJTSritojP4omd9u0sVL75Hb4=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "13.2.4",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/yargs/-/yargs-13.2.4.tgz",
+          "integrity": "sha1-C1YreUAW65ZRuYvTes82SqXW3IM=",
+          "dev": true,
+          "requires": {
+            "cliui": "^5.0.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "os-locale": "^3.1.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^13.1.0"
+          }
+        }
+      }
+    },
+    "webpack-sources": {
+      "version": "1.4.3",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/webpack-sources/-/webpack-sources-1.4.3.tgz",
+      "integrity": "sha1-7t2OwLko+/HL/plOItLYkPMwqTM=",
+      "dev": true,
+      "requires": {
+        "source-list-map": "^2.0.0",
+        "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true
+        }
+      }
+    },
     "which": {
       "version": "1.3.1",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/which/-/which-1.3.1.tgz",
@@ -3460,6 +6987,15 @@
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha1-YQY29rH3A4kb00dxzLF/uTtHB5w=",
       "dev": true
+    },
+    "worker-farm": {
+      "version": "1.7.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/worker-farm/-/worker-farm-1.7.0.tgz",
+      "integrity": "sha1-JqlMU5G7ypJhUgAvabhKS/dy5ag=",
+      "dev": true,
+      "requires": {
+        "errno": "~0.1.7"
+      }
     },
     "wrap-ansi": {
       "version": "5.1.0",
@@ -3528,10 +7064,22 @@
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
       "integrity": "sha1-vpuuHIoEbnazESdyY0fQrXACvrM="
     },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha1-u3J3n1+kZRhrH0OPZ0+jR/2121Q=",
+      "dev": true
+    },
     "y18n": {
       "version": "4.0.0",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/y18n/-/y18n-4.0.0.tgz",
       "integrity": "sha1-le+U+F7MgdAHwmThkKEg8KPIVms="
+    },
+    "yallist": {
+      "version": "3.1.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha1-27fa+b/YusmrRev2ArjLrQ1dCP0=",
+      "dev": true
     },
     "yargs": {
       "version": "13.3.2",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Planning Domain Description Language support",
   "author": "Jan Dolejsi",
   "license": "MIT",
-  "version": "2.17.3",
+  "version": "2.17.4",
   "publisher": "jan-dolejsi",
   "engines": {
     "vscode": "^1.44.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "onView:pddl.tests.explorer",
     "onUri"
   ],
-  "main": "./out/extension",
+  "main": "./dist/extension",
   "contributes": {
     "languages": [
       {
@@ -964,8 +964,10 @@
     "compile": "tsc -p ./",
     "watch": "tsc -w -p ./",
     "lint": "eslint src --ext ts",
-    "vscode:prepublish": "npm run compile",
+    "vscode:prepublish": "webpack --mode production",
     "update-vscode": "node ./node_modules/vscode/bin/install",
+    "webpack": "webpack --mode development",
+    "webpack-dev": "webpack --mode development --watch",
     "package": "vsce package",
     "pretest": "npm run compile",
     "test:unit": "mocha -- out/test/**/*Test.js",
@@ -1014,8 +1016,11 @@
     "minimist": ">=0.2.1",
     "mocha": "^6.1.4",
     "tmp-promise": "^2.0.2",
+    "ts-loader": "^7.0.3",
     "typescript": "^3.7.3",
     "vsce": "^1.75.0",
-    "vscode-test": "^1.0.0"
+    "vscode-test": "^1.0.0",
+    "webpack": "^4.43.0",
+    "webpack-cli": "^3.3.11"
   }
 }

--- a/src/configuration/ExtensionInfo.ts
+++ b/src/configuration/ExtensionInfo.ts
@@ -15,7 +15,7 @@ export class ExtensionInfo {
         const extension = extensions.getExtension(extensionId);
         if (extension === undefined) { throw new Error('Extension not found: ' + ExtensionInfo.EXTENSION_ID); }
         this.extensionId = extension.id;
-        this.extensionVersion = extension.packageJSON["version"] as string;
+        this.extensionVersion = (extension.packageJSON as ExtensionPackage).version;
     }
 
     getId(): string {
@@ -25,4 +25,10 @@ export class ExtensionInfo {
     getVersion(): string {
         return this.extensionVersion;
     }
+}
+
+export interface ExtensionPackage {
+	name: string;
+    publisher: string;
+    version: string;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,7 +19,7 @@ import { StartUp } from './init/StartUp';
 import { PTestExplorer } from './ptest/PTestExplorer';
 import { PlanValidator } from './diagnostics/PlanValidator';
 import { Debugging } from './debugger/debugging';
-import { ExtensionInfo } from './configuration/ExtensionInfo';
+import { ExtensionInfo, ExtensionPackage } from './configuration/ExtensionInfo';
 import { HappeningsValidator } from './diagnostics/HappeningsValidator';
 import { PlanComparer } from './comparison/PlanComparer';
 import { Catalog } from './catalog/Catalog';
@@ -303,9 +303,4 @@ function registerDocumentFormattingProvider(context: ExtensionContext, pddlWorks
 	else {
 		return false;
 	}
-}
-
-export interface ExtensionPackage {
-	name: string;
-	publisher: string;
 }

--- a/src/planning/PlanReportGenerator.ts
+++ b/src/planning/PlanReportGenerator.ts
@@ -125,9 +125,8 @@ States evaluated: ${plan.statesEvaluated}`;
         if (planVisualizerPath && plan.domain) {
             const absPath = path.join(PddlWorkspace.getFolderPath(plan.domain.fileUri), planVisualizerPath);
             try {
-                delete require.cache[require.resolve(absPath)];
-                // eslint-disable-next-line @typescript-eslint/no-var-requires
-                const visualize = require(absPath);
+                const planVisualizerText = (await workspace.fs.readFile(Uri.file(absPath))).toString();
+                const visualize = eval(planVisualizerText);
                 stateViz = visualize(plan, 300, 100);
                 // todo: document.getElementById("stateviz").innerHTML = stateViz;
                 stateViz = `<div class="stateView" plan="${planIndex}" style="margin: 5px; width: 300px; height: 100px; display: ${styleDisplay};">${stateViz}</div>`;

--- a/src/ptest/PTestExplorer.ts
+++ b/src/ptest/PTestExplorer.ts
@@ -63,7 +63,7 @@ export class PTestExplorer {
         this.subscribe(instrumentOperationAsVsCodeCommand('pddl.tests.problemSaveAs', () => this.saveProblemAs().catch(showError)));
 
         this.subscribe(instrumentOperationAsVsCodeCommand(PTEST_REVEAL, nodeUri =>
-            this.pTestViewer.reveal(this.pTestTreeDataProvider.findNodeByResource(nodeUri), { select: true, expand: true }))
+            this.pTestViewer.reveal(this.pTestTreeDataProvider.findNodeByResourceOrThrow(nodeUri), { select: true, expand: true }).then(() => { return; }, showError))
         );
 
         this.manifestGenerator = new ManifestGenerator(this.codePddlWorkspace.pddlWorkspace, this.context);

--- a/src/ptest/PTestTreeDataProvider.ts
+++ b/src/ptest/PTestTreeDataProvider.ts
@@ -48,11 +48,16 @@ export class PTestTreeDataProvider implements TreeDataProvider<PTestNode> {
     setTestOutcome(test: Test, testOutcome: TestOutcome): void {
         this.testResults.set(test.getUriOrThrow().toString(), testOutcome);
         const node = this.findNodeByResource(test.getUriOrThrow());
-        this._onDidChange.fire(node);
+        // the node may not exist, if the tree hasn't been expanded yet
+        node && this._onDidChange.fire(node);
+    }
+
+    findNodeByResourceOrThrow(resource: Uri): PTestNode {
+        return assertDefined(this.findNodeByResourceOrThrow(resource), `No node for ${resource.toString()}`);
     }
 
     findNodeByResource(resource: Uri): PTestNode {
-        return assertDefined(this.treeNodeCache.get(resource.toString()), `No node for ${resource.toString()}`);
+        return this.treeNodeCache.get(resource.toString());
     }
 
     cache(node: PTestNode): PTestNode {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,13 +5,15 @@
 		"noUnusedParameters": true,
 		"noImplicitAny": true,
 		"noImplicitReturns": true,		
-		"target": "es6",
+		"target": "ES2019",
+		"lib": [
+			"es2019"
+		],
 		"module": "commonjs",
 		"moduleResolution": "node",
 		"forceConsistentCasingInFileNames": true,
 		"rootDir": "src",
 		"outDir": "out",
-		"lib": [ "es6" ],
 		"sourceMap": true
 	},
 	"exclude": [

--- a/views/searchview/search.js
+++ b/views/searchview/search.js
@@ -333,7 +333,7 @@ shapeMap['e'] = 'ellipse';
 function navigate(e) {
     e = e || window.event;
     /** @type{number | undefined} */
-    const newSelectedStateId = undefined;
+    let newSelectedStateId = undefined;
     switch (e.key) {
         case "ArrowLeft":
             newSelectedStateId = e.shiftKey ? navigateChart(-1) : navigateTreeSiblings(-1);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,43 @@
+//@ts-check
+
+'use strict';
+
+const path = require('path');
+
+/** @type {import('webpack').Configuration} */
+const config = {
+    target: 'node',
+    entry: './src/extension.ts',
+    output: {
+        path: path.resolve(__dirname, 'dist'),
+        filename: 'extension.js',
+        libraryTarget: "commonjs2",
+        devtoolModuleFilenameTemplate: '../[resource-path]'
+    },
+    devtool: 'source-map',
+    externals: {
+        vscode: 'commonjs vscode' // todo: anything else?
+    },
+    resolve: {
+        extensions: ['.ts', '.js']
+    },
+    module: {
+        rules: [
+            {
+                test: /\.ts$/,
+                exclude: /node_modules/,
+                use: [
+                    {
+                        loader: 'ts-loader',
+                /*options: {
+                    compilerOptions: {
+                        "module": "es6" // override `tsconfig.json` so that TypeScript emits native JavaScript modules.
+                    }
+                }*/
+                    }
+                ]
+            }
+        ]
+    }
+};
+module.exports = config;


### PR DESCRIPTION
## 2.17.4

- Faster start-up time due to migration to Webpack. Please report any errors that fell through my week of hands-on usage/testing.
- Fixed bug, where the test results/outcomes were not being displayed on the tree, if the tree was first-time-expanded _during_ the execution of the tests.
- Fixed regression on the visual search debugger related to selection of nodes on the tree.