### PR TITLE
v2.18.0 - multiple plan metric line plots

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -8,7 +8,6 @@ src/**
 tsconfig.json
 *.cmd
 .vscode-test/**
-val/**
 .vscodeignore
 package-lock.json
 .eslintrc.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # PDDL support - What's new?
 
+## 2.17.4
+
+- Fixed bug, where the test results/outcomes were not being displayed on the tree, if the tree was first-time-expanded _during_ the execution of the tests.
+- Fixed regression on the visual search debugger related to selection of nodes on the tree.
+- Fixed response to failing plan validation. Instead of opening the _Problems_ pane, we open the _Output_ pane, where the detailed VAL output is printed.
+- Val std-error stream is also now presented in the _Problems_ pane.
+- Small fix for the Overview Page, when it is closed before the current configuration is posted to it.
+- Support for DAY (and WEEK) time resolution in plans.
+- To minimize the refresh of plan visualization, the plans are _no longer_ re-painted when upon the planner exit.
+- Step up to target ES2019
+
 ## 2.17.3
 
 Escaping spaces in VAL paths on MacOS.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,32 @@
 # PDDL support - What's new?
 
-## 2.17.4
+## 2.18.0
+
+### Features
+
+### Line plots for multiple metric expressions
+
+If your planner supports multiple `(:metric ...)` expressions in the problem file (VAL actually does),
+you can use it to get some ad-hoc expressions displayed on a line plot below the plan.
+This is very useful, to debug numerically-rich domains.
+
+![Plan metric plots](https://raw.githubusercontent.com/wiki/jan-dolejsi/vscode-pddl/img/plan_metric_plots.jpg)
+
+### Other improvements
+
+- Auto completion for (:constraints ) includes the nested (and ), which I always forget
+- Val std-error stream is also now presented in the _Problems_ pane.
+- Support for DAY (and WEEK) time resolution in plans.
+- To minimize the refresh of plan visualization, the plans are _no longer_ re-painted when upon the planner exit.
+
+### Fixes
 
 - Fixed bug, where the test results/outcomes were not being displayed on the tree, if the tree was first-time-expanded _during_ the execution of the tests.
 - Fixed regression on the visual search debugger related to selection of nodes on the tree.
 - Fixed response to failing plan validation. Instead of opening the _Problems_ pane, we open the _Output_ pane, where the detailed VAL output is printed.
-- Val std-error stream is also now presented in the _Problems_ pane.
 - Small fix for the Overview Page, when it is closed before the current configuration is posted to it.
-- Support for DAY (and WEEK) time resolution in plans.
-- To minimize the refresh of plan visualization, the plans are _no longer_ re-painted when upon the planner exit.
+- Async service call handles multiple plans and xml plan format
+- Fixed bug that caused the extension to hang in an endless loop, while resolving a PDDL symbol references (while hover-over)
 - Step up to target ES2019
 
 ## 2.17.3
@@ -1019,7 +1037,8 @@ Note for open source contributors: all notable changes to the "pddl" extension w
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
-[Unreleased]: https://github.com/jan-dolejsi/vscode-pddl/compare/v2.17.1...HEAD
+[Unreleased]: https://github.com/jan-dolejsi/vscode-pddl/compare/v2.18.0...HEAD
+[2.16.0]:https://github.com/jan-dolejsi/vscode-pddl/compare/v2.17.1...v2.18.0
 [2.16.0]:https://github.com/jan-dolejsi/vscode-pddl/compare/v2.16.0...v2.17.1
 [2.15.7]:https://github.com/jan-dolejsi/vscode-pddl/compare/v2.15.7...v2.16.0
 [2.15.7]:https://github.com/jan-dolejsi/vscode-pddl/compare/v2.15.6...v2.15.7

--- a/README.md
+++ b/README.md
@@ -163,6 +163,15 @@ If one of the rules above is not satisfied, the editor will not naturally associ
 
 ![domain/problem/plann associations](https://raw.githubusercontent.com/wiki/jan-dolejsi/vscode-pddl/img/PDDL_explicit_domain-problem-plan_associations.gif)
 
+#### Line plots for multiple metric expressions
+
+If your planner supports multiple `(:metric ...)` expressions in the problem file (VAL actually does),
+you can use it to get some ad-hoc expressions displayed on a line plot below the plan.
+This is very useful, to debug numerically-rich domains.
+
+![Plan metric plots](https://raw.githubusercontent.com/wiki/jan-dolejsi/vscode-pddl/img/plan_metric_plots.jpg)
+
+
 #### Running the planner interactively
 
 See configuration setting `pddlPlanner.executionTarget` to select where is the planner executable started. You can either direct planner executable output to a _Terminal_ window instead of the _Output window_. This can be configured on the _Overview page_.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pddl",
-  "version": "2.17.4",
+  "version": "2.18.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -373,13 +373,13 @@
       }
     },
     "ai-planning-val": {
-      "version": "2.1.7",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/ai-planning-val/-/ai-planning-val-2.1.7.tgz",
-      "integrity": "sha1-PqsAKrmM0r3c69kyqdcZUVkkfQY=",
+      "version": "2.2.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/ai-planning-val/-/ai-planning-val-2.2.0.tgz",
+      "integrity": "sha1-ibs9vB7N2GUtKDpDrgsQBwj7GKE=",
       "requires": {
         "adm-zip": "^0.4.14",
         "events": "^3.1.0",
-        "pddl-workspace": "^3.0.0",
+        "pddl-workspace": "^3.2.0",
         "request": "^2.88.2",
         "yargs": "^15.3.1"
       },
@@ -690,7 +690,7 @@
     },
     "balanced-match": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "bcrypt-pbkdf": {
@@ -947,7 +947,7 @@
     },
     "color-name": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
@@ -966,7 +966,7 @@
     },
     "concat-map": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "content-disposition": {
@@ -1281,7 +1281,7 @@
     },
     "escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
@@ -1687,7 +1687,7 @@
     },
     "fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
@@ -1788,7 +1788,7 @@
     },
     "has-flag": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
@@ -1920,7 +1920,7 @@
     },
     "inflight": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
         "once": "^1.3.0",
@@ -1929,7 +1929,7 @@
     },
     "inherits": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "inquirer": {
@@ -2528,7 +2528,7 @@
     },
     "once": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
         "wrappy": "1"
@@ -2669,7 +2669,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-key": {
@@ -2690,9 +2690,9 @@
       "dev": true
     },
     "pddl-workspace": {
-      "version": "3.1.0",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/pddl-workspace/-/pddl-workspace-3.1.0.tgz",
-      "integrity": "sha1-sAq/YG9Aa2zgzjkuQ6uA/oBUUOY=",
+      "version": "3.2.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/pddl-workspace/-/pddl-workspace-3.2.0.tgz",
+      "integrity": "sha1-3Fg7GMJwECRfGTVpPH4QxDzeVrc=",
       "requires": {
         "nunjucks": "^3.2.0",
         "parse-xsd-duration": "^0.5.0",
@@ -2998,7 +2998,7 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
@@ -3502,7 +3502,7 @@
     },
     "wrappy": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pddl",
-  "version": "2.17.3",
+  "version": "2.17.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -690,7 +690,7 @@
     },
     "balanced-match": {
       "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/balanced-match/-/balanced-match-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "bcrypt-pbkdf": {
@@ -947,7 +947,7 @@
     },
     "color-name": {
       "version": "1.1.3",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/color-name/-/color-name-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
@@ -966,7 +966,7 @@
     },
     "concat-map": {
       "version": "0.0.1",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/concat-map/-/concat-map-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "content-disposition": {
@@ -1281,7 +1281,7 @@
     },
     "escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
@@ -1687,7 +1687,7 @@
     },
     "fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
@@ -1788,7 +1788,7 @@
     },
     "has-flag": {
       "version": "3.0.0",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/has-flag/-/has-flag-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
@@ -1920,7 +1920,7 @@
     },
     "inflight": {
       "version": "1.0.6",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/inflight/-/inflight-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
         "once": "^1.3.0",
@@ -1929,7 +1929,7 @@
     },
     "inherits": {
       "version": "2.0.3",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/inherits/-/inherits-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "inquirer": {
@@ -2528,7 +2528,7 @@
     },
     "once": {
       "version": "1.4.0",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/once/-/once-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
         "wrappy": "1"
@@ -2669,7 +2669,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-key": {
@@ -2998,7 +2998,7 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
@@ -3502,7 +3502,7 @@
     },
     "wrappy": {
       "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/wrappy/-/wrappy-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Planning Domain Description Language support",
   "author": "Jan Dolejsi",
   "license": "MIT",
-  "version": "2.17.3",
+  "version": "2.17.4",
   "publisher": "jan-dolejsi",
   "engines": {
     "vscode": "^1.44.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Planning Domain Description Language support",
   "author": "Jan Dolejsi",
   "license": "MIT",
-  "version": "2.17.4",
+  "version": "2.18.0",
   "publisher": "jan-dolejsi",
   "engines": {
     "vscode": "^1.44.0",
@@ -973,14 +973,14 @@
     "test": "npm run test:unit && npm run test:integration"
   },
   "dependencies": {
-    "ai-planning-val": "^2.1.7",
+    "ai-planning-val": "^2.2.0",
     "await-notify": "^1.0.1",
     "body-parser": "^1.19.0",
     "events": "^3.1.0",
     "express": "^4.17.1",
     "jsonc-parser": "^2.2.1",
     "open": "^7.0.2",
-    "pddl-workspace": "^3.1.0",
+    "pddl-workspace": "^3.2.0",
     "request": "^2.88.2",
     "semver": "^7.1.3",
     "tree-kill": "^1.2.2",

--- a/src/completion/AbstractCompletionItemProvider.ts
+++ b/src/completion/AbstractCompletionItemProvider.ts
@@ -59,7 +59,7 @@ export class AbstractCompletionItemProvider {
     }
 
     protected addConstraintsDocumentation(): void {
-        this.addSuggestionDocumentation(':constraints', 'Constraints', 'Constraints.... you may want to stay away from those.');
+        this.addSuggestionDocumentation(':constraints', 'Constraints', 'Constraints that all plans must satisfy.');
     }
 
     protected addRequirementsDocumentation(): void {

--- a/src/completion/DomainCompletionItemProvider.ts
+++ b/src/completion/DomainCompletionItemProvider.ts
@@ -190,7 +190,7 @@ export class DomainCompletionItemProvider extends AbstractCompletionItemProvider
             case parser.PddlStructure.PREDICATES:
             case parser.PddlStructure.FUNCTIONS:
             case parser.PddlStructure.CONSTRAINTS:
-                return this.createSnippetCompletionItem(suggestion, "(" + suggestion.sectionName + " \n\t$0\n)", range, context, index);
+                return this.createSnippetCompletionItem(suggestion, "(" + suggestion.sectionName + " (and\n\t$0\n))", range, context, index);
 
             case parser.PddlStructure.ACTION:
                 return this.createSnippetCompletionItem(suggestion, ["(:action ${1:action_name}",

--- a/src/completion/ProblemCompletionItemProvider.ts
+++ b/src/completion/ProblemCompletionItemProvider.ts
@@ -92,7 +92,7 @@ export class ProblemCompletionItemProvider extends AbstractCompletionItemProvide
             case parser.PddlStructure.OBJECTS:
             case parser.PddlStructure.INIT:
             case parser.PddlStructure.CONSTRAINTS:
-                return this.createSnippetCompletionItem(suggestion, "(" + suggestion.sectionName + " \n\t$0\n)", range, context, index);
+                return this.createSnippetCompletionItem(suggestion, "(" + suggestion.sectionName + " (and\n\t$0\n))", range, context, index);
             case parser.PddlStructure.GOAL:
                 return this.createSnippetCompletionItem(suggestion, "(" + suggestion.sectionName + " (and\n\t$0\n))", range, context, index);
             case parser.PddlStructure.METRIC:

--- a/src/init/OverviewPage.ts
+++ b/src/init/OverviewPage.ts
@@ -325,7 +325,7 @@ export class OverviewPage {
             updateValAlert: await this.val.isNewValVersionAvailable()
             // todo: workbench.editor.revealIfOpen
         };
-        return this.webViewPanel.webview.postMessage(message);
+        return this.webViewPanel.webview?.postMessage(message) ?? false;
     }
 
     private toWireWorkspaceFolder(workspaceFolder: WorkspaceFolder): WireWorkspaceFolder {

--- a/src/planning/PlanReportGenerator.ts
+++ b/src/planning/PlanReportGenerator.ts
@@ -200,11 +200,23 @@ ${objectsHtml}
 
                     functionValues.forEach((values, liftedVariable) => {
                         const chartDivId = `chart_${planIndex}_${liftedVariable.declaredName}`;
-                        lineCharts += `        <div id="${chartDivId}" style="width: ${this.options.displayWidth + 100}px; height: ${Math.round(this.options.displayWidth / 2)}px"></div>\n`;
+                        lineCharts += this.createLineChartDiv(chartDivId);
                         let chartTitleWithUnit = values.legend.length > 1 ? liftedVariable.name : liftedVariable.getFullName();
                         if (liftedVariable.getUnit()) { chartTitleWithUnit += ` [${liftedVariable.getUnit()}]`; }
                         lineChartScripts += `        drawChart('${chartDivId}', '${chartTitleWithUnit}', '', ${JSON.stringify(values.legend)}, ${JSON.stringify(values.values)}, ${this.options.displayWidth});\n`;
                     });
+
+                    // add one plot for declared metric
+                    for (let metricIndex = 0; metricIndex < plan.problem.getMetrics().length; metricIndex++) {
+                        const metric = plan.problem.getMetrics()[metricIndex];
+
+                        const metricValues = await evaluator.evaluateExpression(metric.getExpression());
+                        const chartDivId = `chart_${planIndex}_metric${metricIndex}`;
+                        lineCharts += this.createLineChartDiv(chartDivId);
+                        const chartTitleWithUnit = metric.getDocumentation()[metric.getDocumentation().length - 1];
+                        lineChartScripts += `        drawChart('${chartDivId}', '${chartTitleWithUnit}', '', ['${/*unit?*/""}'], ${JSON.stringify(metricValues.values)}, ${this.options.displayWidth});\n`;
+                    }
+
                 } catch (err) {
                     console.error(err);
                     const valStepPath = evaluator.getValStepPath();
@@ -226,6 +238,10 @@ ${swimLanes}
 ${lineCharts}
         <script>function drawPlan${planIndex}Charts(){\n${lineChartScripts}}</script>
 `;
+    }
+
+    private createLineChartDiv(chartDivId: string): string {
+        return `        <div id="${chartDivId}" style="width: ${this.options.displayWidth + 100}px; height: ${Math.round(this.options.displayWidth / 2)}px"></div>\n`;
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/planning/PlannerAsyncService.ts
+++ b/src/planning/PlannerAsyncService.ts
@@ -66,6 +66,10 @@ export class PlannerAsyncService extends PlannerService {
                 return 1 / 1000;
             case "HOUR":
                 return 60 * 60;
+            case "DAY":
+                return 24 * 60 * 60;
+            case "WEEK":
+                return 7 * 24 * 60 * 60;
             case "SECOND":
             default:
                 return 1;

--- a/src/planning/planning.ts
+++ b/src/planning/planning.ts
@@ -484,8 +484,10 @@ export class Planning implements planner.PlannerResponseHandler {
     }
 
     visualizePlans(plans: Plan[]): void {
-        this.plans = plans;
-        this.planView.setPlannerOutput(plans, !this.isSearchDebugger());
+        if (this.plans !== plans) {
+            this.plans = plans;
+            this.planView.setPlannerOutput(plans, !this.isSearchDebugger());
+        }
     }
 
     static q(path: string): string {

--- a/src/ptest/PTestExplorer.ts
+++ b/src/ptest/PTestExplorer.ts
@@ -63,7 +63,7 @@ export class PTestExplorer {
         this.subscribe(instrumentOperationAsVsCodeCommand('pddl.tests.problemSaveAs', () => this.saveProblemAs().catch(showError)));
 
         this.subscribe(instrumentOperationAsVsCodeCommand(PTEST_REVEAL, nodeUri =>
-            this.pTestViewer.reveal(this.pTestTreeDataProvider.findNodeByResource(nodeUri), { select: true, expand: true }))
+            this.pTestViewer.reveal(this.pTestTreeDataProvider.findNodeByResourceOrThrow(nodeUri), { select: true, expand: true }).then(() => { return; }, showError))
         );
 
         this.manifestGenerator = new ManifestGenerator(this.codePddlWorkspace.pddlWorkspace, this.context);

--- a/src/ptest/PTestTreeDataProvider.ts
+++ b/src/ptest/PTestTreeDataProvider.ts
@@ -48,11 +48,16 @@ export class PTestTreeDataProvider implements TreeDataProvider<PTestNode> {
     setTestOutcome(test: Test, testOutcome: TestOutcome): void {
         this.testResults.set(test.getUriOrThrow().toString(), testOutcome);
         const node = this.findNodeByResource(test.getUriOrThrow());
-        this._onDidChange.fire(node);
+        // the node may not exist, if the tree hasn't been expanded yet
+        node && this._onDidChange.fire(node);
+    }
+
+    findNodeByResourceOrThrow(resource: Uri): PTestNode {
+        return assertDefined(this.findNodeByResourceOrThrow(resource), `No node for ${resource.toString()}`);
     }
 
     findNodeByResource(resource: Uri): PTestNode {
-        return assertDefined(this.treeNodeCache.get(resource.toString()), `No node for ${resource.toString()}`);
+        return this.treeNodeCache.get(resource.toString());
     }
 
     cache(node: PTestNode): PTestNode {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,13 +5,15 @@
 		"noUnusedParameters": true,
 		"noImplicitAny": true,
 		"noImplicitReturns": true,		
-		"target": "es6",
+		"target": "ES2019",
+		"lib": [
+			"es2019"
+		],
 		"module": "commonjs",
 		"moduleResolution": "node",
 		"forceConsistentCasingInFileNames": true,
 		"rootDir": "src",
 		"outDir": "out",
-		"lib": [ "es6" ],
 		"sourceMap": true
 	},
 	"exclude": [

--- a/views/planview/charts.js
+++ b/views/planview/charts.js
@@ -17,7 +17,8 @@ function drawChart(chartDivId, functionName, unit, objects, columnData) {
             title: 'Time'
         },
         vAxis: {
-            title: unit
+            title: unit,
+            scaleType: 'linear' //vAxisScaleType = 'log'
         },
         interpolateNulls: true,
         title: functionName
@@ -46,7 +47,8 @@ function drawChartMultipleSeries(chartDivId, functionName, unit, objects, column
             title: 'Time'
         },
         vAxis: {
-            title: unit
+            title: unit,
+            scaleType: 'linear' //vAxisScaleType = 'log'
         },
         interpolateNulls: true,
         title: functionName

--- a/views/searchview/search.js
+++ b/views/searchview/search.js
@@ -333,7 +333,7 @@ shapeMap['e'] = 'ellipse';
 function navigate(e) {
     e = e || window.event;
     /** @type{number | undefined} */
-    const newSelectedStateId = undefined;
+    let newSelectedStateId = undefined;
     switch (e.key) {
         case "ArrowLeft":
             newSelectedStateId = e.shiftKey ? navigateChart(-1) : navigateTreeSiblings(-1);


### PR DESCRIPTION
## 2.18.0

### Features

### Line plots for multiple metric expressions

If your planner supports multiple `(:metric ...)` expressions in the problem file (VAL actually does),
you can use it to get some ad-hoc expressions displayed on a line plot below the plan.
This is very useful, to debug numerically-rich domains.

![Plan metric plots](https://raw.githubusercontent.com/wiki/jan-dolejsi/vscode-pddl/img/plan_metric_plots.jpg)

### Other improvements

- Auto completion for (:constraints ) includes the nested (and ), which I always forget
- Val std-error stream is also now presented in the _Problems_ pane.
- Support for DAY (and WEEK) time resolution in plans.
- To minimize the refresh of plan visualization, the plans are _no longer_ re-painted when upon the planner exit.

### Fixes

- Fixed bug, where the test results/outcomes were not being displayed on the tree, if the tree was first-time-expanded _during_ the execution of the tests.
- Fixed regression on the visual search debugger related to selection of nodes on the tree.
- Fixed response to failing plan validation. Instead of opening the _Problems_ pane, we open the _Output_ pane, where the detailed VAL output is printed.
- Small fix for the Overview Page, when it is closed before the current configuration is posted to it.
- Async service call handles multiple plans and xml plan format
- Fixed bug that caused the extension to hang in an endless loop, while resolving a PDDL symbol references (while hover-over)
- Step up to target ES2019
