### PR TITLE
sync/async local service start suggestion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # PDDL support - What's new?
 
+## 2.22.1
+
+- Planning service, which specifies both the `url` and `path` in the planner configuration, may be started by the user, as long as the `url` is local. The service then runs as a _Task_ in a new _Terminal_ inside VS Code
+  ![Planning service start suggestion](https://raw.githubusercontent.com/wiki/jan-dolejsi/vscode-pddl/img/pddl_planning_service_start-up.gif)
+
 ## [2.22.0]
 
 - When one or two PDDL files (i.e. domain and/or problem) are selected in the File Explorer and the context menu includes the _PDDL: Run the planner and display the plan_ command. This is extra helpful, when the domain and problem files are in different folders.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Planning Domain Description Language support",
   "author": "Jan Dolejsi",
   "license": "MIT",
-  "version": "2.22.0",
+  "version": "2.22.1",
   "publisher": "jan-dolejsi",
   "engines": {
     "vscode": "^1.50.0",

--- a/src/planning/planning.ts
+++ b/src/planning/planning.ts
@@ -360,7 +360,7 @@ export class Planning implements planner.PlannerResponseHandler {
             this.progressUpdater = new ElapsedTimeProgressUpdater(progress, token);
             return planner.plan(domainFileInfo, problemFileInfo, planParser, this);
         })
-            .then(plans => this.onPlannerFinished(plans), reason => this.onPlannerFailed(reason, planner));
+            .then(plans => this.onPlannerFinished(plans), reason => this.onPlannerFailed(reason, planner).catch(showError));
     }
 
     isSearchDebugger(): boolean {


### PR DESCRIPTION
## 2.22.1

- Planning service, which specifies both the `url` and `path` in the planner configuration, may be started by the user, as long as the `url` is local. The service then runs as a _Task_ in a new _Terminal_ inside VS Code
  ![Planning service start suggestion](https://raw.githubusercontent.com/wiki/jan-dolejsi/vscode-pddl/img/pddl_planning_service_start-up.gif)
