### PR TITLE
planutils server support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,47 @@
 # PDDL support - What's new?
 
+## 2.25.0
+
+### Planutil server support
+
+Install the [planutils](https://pypi.org/project/planutils/) package if you are on a Linux-like envoirnment or can activate the WSL Windows Subsystem for Linux (as mentioned below). You will have a whole bunch  of planners suddenly at your fingertips.
+
+#### Installing `planutils`
+
+If you are on a linux-based environment, or use WSL on Windows, follow these steps to install [`planutils`](https://pypi.org/project/planutils/) there.
+
+If you can run `docker` on your system, [follow the instructions for Docker](https://pypi.org/project/planutils/).
+
+If you can just use Python, here is what you need to do:
+
+```bash
+pip install planutils
+planutils setup
+planutils activate
+```
+
+if `planutils` does not seem to be available, refresh the bash context to read in the updated `path`.
+
+Instally any planner you want, e.g. ...
+
+```bash
+planutils install lama
+```
+
+Start the service. (replicating what [Docker would do for you automatically](https://github.com/AI-Planning/planutils/blob/main/environments/server/Dockerfile)):
+
+```bash
+pip install flask
+
+planutils server --port 5555
+```
+
+Add a planner of the type _Planutils server_ and keep the address as suggested `http://localhost:5555/package`. Plan. Enjoy.
+
+### Bracket-pairing guide lines
+
+Guide lines between colored bracket pairs help readability of poorly formatted PDDL code.
+
 ## 2.24.0
 
 ### WSL Windows Subsystem for Linux support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # PDDL support - What's new?
 
-## 2.25.0
+## 2.25.0 and Happy New Year, planning community
 
 ### Planutil server support
 
-Install the [planutils](https://pypi.org/project/planutils/) package if you are on a Linux-like envoirnment or can activate the WSL Windows Subsystem for Linux (as mentioned below). You will have a whole bunch  of planners suddenly at your fingertips.
+Install the [planutils](https://pypi.org/project/planutils/) if you are on a Linux-like envoirnment or can activate the WSL Windows Subsystem for Linux (as mentioned below). You will have a whole bunch  of planners suddenly at your fingertips.
+
+![Planutils server](https://raw.githubusercontent.com/wiki/jan-dolejsi/vscode-pddl/img/planutils-server.gif)
 
 #### Installing `planutils`
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,35 @@ this spec:
 
 #### Installing `planutils`
 
-Support coming soon.
+If you are on a linux-based environment, or use WSL on Windows, follow these steps to install [`planutils`](https://pypi.org/project/planutils/) there.
+
+If you can run `docker` on your system, [follow the instructions for Docker](https://pypi.org/project/planutils/).
+
+If you can just use Python, here is what you need to do:
+
+```bash
+pip install planutils
+planutils setup
+planutils activate
+```
+
+if `planutils` does not seem to be available, refresh the bash context to read in the updated `path`.
+
+Instally any planner you want, e.g. ...
+
+```bash
+planutils install lama
+```
+
+Start the service. (replicating what [Docker would do for you automatically](https://github.com/AI-Planning/planutils/blob/main/environments/server/Dockerfile)):
+
+```bash
+pip install flask
+
+planutils server --port 5555
+```
+
+Add a planner of the type _Planutils server_ and keep the address as suggested `http://localhost:5555/package`. Plan. Enjoy.
 
 ### Explore VS Code PDDL show-cases
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ this spec:
 * [How to configure your PDDL parser to be used by this extension.](https://github.com/jan-dolejsi/vscode-pddl/wiki/Configuring-the-PDDL-parser)
 * [How to configure your PDDL planner to be used by this extension.](https://github.com/jan-dolejsi/vscode-pddl/wiki/Configuring-the-PDDL-planner)
 
-#### Installing `planutils`
+#### Install `planutils` to have 20+ planners at your fingertips
+
+![Planutils server](https://raw.githubusercontent.com/wiki/jan-dolejsi/vscode-pddl/img/planutils-server.gif)
 
 If you are on a linux-based environment, or use WSL on Windows, follow these steps to install [`planutils`](https://pypi.org/project/planutils/) there.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pddl",
-  "version": "2.24.9",
+  "version": "2.25.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pddl",
-      "version": "2.24.9",
+      "version": "2.25.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pddl",
-  "version": "2.23.5",
+  "version": "2.24.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pddl",
-      "version": "2.23.5",
+      "version": "2.24.9",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -17,7 +17,7 @@
         "jsonc-parser": "^3.0.0",
         "open": "^8.0.6",
         "pddl-gantt": "^1.5.12",
-        "pddl-planning-service-client": "^2.2.1",
+        "pddl-planning-service-client": "^2.2.2",
         "pddl-workspace": "^7.2.2",
         "request": "^2.88.2",
         "semver": "^7.3.5",
@@ -5046,9 +5046,9 @@
       }
     },
     "node_modules/pddl-planning-service-client": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/pddl-planning-service-client/-/pddl-planning-service-client-2.2.1.tgz",
-      "integrity": "sha512-wzh7szteJ0hvr9BktjTMZKnFhcqWruITTqSt6pKPfeMmCNRkL7b4jL+PaifugvRQUHPKXxjvDjH+86TGHkXtsA==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/pddl-planning-service-client/-/pddl-planning-service-client-2.2.2.tgz",
+      "integrity": "sha512-LnXbeOMPVc81C3K+8m46kV/V4tHZbPYMaE7JM8PreaIcJHORkf4t0IchvmDicRMc31wfAKD95VzzAyApxOqLlA==",
       "dependencies": {
         "parse-xsd-duration": "^0.5.0",
         "pddl-workspace": "^7.2.2",
@@ -10554,9 +10554,9 @@
       }
     },
     "pddl-planning-service-client": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/pddl-planning-service-client/-/pddl-planning-service-client-2.2.1.tgz",
-      "integrity": "sha512-wzh7szteJ0hvr9BktjTMZKnFhcqWruITTqSt6pKPfeMmCNRkL7b4jL+PaifugvRQUHPKXxjvDjH+86TGHkXtsA==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/pddl-planning-service-client/-/pddl-planning-service-client-2.2.2.tgz",
+      "integrity": "sha512-LnXbeOMPVc81C3K+8m46kV/V4tHZbPYMaE7JM8PreaIcJHORkf4t0IchvmDicRMc31wfAKD95VzzAyApxOqLlA==",
       "requires": {
         "parse-xsd-duration": "^0.5.0",
         "pddl-workspace": "^7.2.2",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Planning Domain Description Language support",
   "author": "Jan Dolejsi",
   "license": "MIT",
-  "version": "2.24.9",
+  "version": "2.25.0",
   "publisher": "jan-dolejsi",
   "engines": {
     "vscode": "^1.69.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Planning Domain Description Language support",
   "author": "Jan Dolejsi",
   "license": "MIT",
-  "version": "2.24.0",
+  "version": "2.24.9",
   "publisher": "jan-dolejsi",
   "engines": {
     "vscode": "^1.69.0",
@@ -675,6 +675,12 @@
               "url": "http://solver.planning.domains/solve",
               "title": "http://solver.planning.domains/solve",
               "canConfigure": false
+            },
+            {
+              "kind": "PLANNING_AS_A_SERVICE_PREVIEW",
+              "url": "http://45.113.232.43:5001/package",
+              "title": "Planning as a service (preview)",
+              "canConfigure": false
             }
           ],
           "items": {
@@ -1037,7 +1043,7 @@
     "jsonc-parser": "^3.0.0",
     "open": "^8.0.6",
     "pddl-gantt": "^1.5.12",
-    "pddl-planning-service-client": "^2.2.1",
+    "pddl-planning-service-client": "^2.2.2",
     "pddl-workspace": "^7.2.2",
     "request": "^2.88.2",
     "semver": "^7.3.5",

--- a/src/configuration/PlannersConfiguration.ts
+++ b/src/configuration/PlannersConfiguration.ts
@@ -9,7 +9,7 @@ import * as path from 'path';
 import { parseTree, findNodeAtLocation } from 'jsonc-parser';
 import { window, commands, workspace, ConfigurationTarget, QuickPickItem, ExtensionContext, StatusBarItem, StatusBarAlignment, Uri, Range, WorkspaceFolder, TextDocument, ViewColumn, env } from 'vscode';
 import { PddlWorkspace, planner } from 'pddl-workspace';
-import { CommandPlannerProvider, SolveServicePlannerProvider, RequestServicePlannerProvider, ExecutablePlannerProvider, Popf, JavaPlannerProvider, Lpg, Pddl4jProvider, PlanningAsAServiceProvider } from './plannerConfigurations';
+import { CommandPlannerProvider, SolveServicePlannerProvider, RequestServicePlannerProvider, ExecutablePlannerProvider, Popf, JavaPlannerProvider, Lpg, Pddl4jProvider, PlanningAsAServiceProvider, PlanutilsServerProvider } from './plannerConfigurations';
 import { CONF_PDDL, PDDL_PLANNER, EXECUTABLE_OR_SERVICE, EXECUTABLE_OPTIONS } from './configuration';
 import { instrumentOperationAsVsCodeCommand } from 'vscode-extension-telemetry-wrapper';
 import { showError, jsonNodeToRange, fileOrFolderExists, isHttp } from '../utils';
@@ -212,6 +212,7 @@ export class PlannersConfiguration {
         [
             new ExecutablePlannerProvider(),
             new CommandPlannerProvider(),
+            new PlanutilsServerProvider(this.context.subscriptions),
             new PlanningAsAServiceProvider(this.context.subscriptions),
             new SolveServicePlannerProvider(this.context.subscriptions),
             new RequestServicePlannerProvider(this.context.subscriptions),

--- a/src/planning/PackagedPlannerSelector.ts
+++ b/src/planning/PackagedPlannerSelector.ts
@@ -24,7 +24,15 @@ export class PackagedPlannerSelector extends PackagedPlanners {
 
     async select(): Promise<SelectedEndpoint | undefined> {
         const manifests = await this.getManifests();
-        const plannerItems = manifests.map(m => this.toManifestQuickPickItem(m));
+        const plannerItems: PackageQuickPickItem[] = [];
+        for (const key in manifests) {
+            if (Object.prototype.hasOwnProperty.call(manifests, key)) {
+                const manifest = manifests[key];
+                manifest.package_name = key;
+                const item = this.toManifestQuickPickItem(manifest);
+                plannerItems.push(item);
+            }
+        }
         const selectedOption = await window.showQuickPick(plannerItems, {
             matchOnDescription: true, matchOnDetail: true, placeHolder: 'Select a planner...'
         });

--- a/src/planning/PlannerArgumentsSelector.ts
+++ b/src/planning/PlannerArgumentsSelector.ts
@@ -24,7 +24,7 @@ export class PlannerArgumentsSelector extends PlannerArgumentsGenerator {
 
     async getConfiguration(): Promise<PackagedServerRequestArgs | null> {
         // check if there actually are any configurable arguments
-        const isConfigurable = this.selectedEndpoint.service.args.some(arg => PlannerArgumentsSelector.isConfigurable(arg));
+        const isConfigurable = this.selectedEndpoint.service.args?.some(arg => PlannerArgumentsSelector.isConfigurable(arg));
 
         if (!isConfigurable) {
             return PlannerArgumentsSelector.DEFAULT;

--- a/src/test/suite/PlannerConfiguration.test.ts
+++ b/src/test/suite/PlannerConfiguration.test.ts
@@ -30,6 +30,8 @@ suite('Planner configuration test', () => {
 		await clearConfiguration();
 	});
 
+	const outOfTheBoxPlanners = 2;
+
 	test('Default planners are returned in blank configuration', () => {
 		const wf = assertDefined(workspace.workspaceFolders, "workspace folders")[0];
 
@@ -37,7 +39,7 @@ suite('Planner configuration test', () => {
 		const planners = plannersConfiguration.getPlanners(wf);
 
 		// THEN
-		expect(planners).to.have.lengthOf(1);
+		expect(planners).to.have.lengthOf(outOfTheBoxPlanners);
 		const defaultPlanner = planners[0];
 		expect(defaultPlanner).to.not.be.undefined;
 		expect(defaultPlanner.scope).to.equal(PlannerConfigurationScope.Default);
@@ -57,7 +59,7 @@ suite('Planner configuration test', () => {
 		const selectedPlanner = plannersConfiguration.getSelectedPlanner(wf);
 
 		// THEN
-		expect(planners).to.have.lengthOf(2);
+		expect(planners).to.have.lengthOf(outOfTheBoxPlanners + 1);
 		const userPlanners = planners.filter(spc => spc.scope === PlannerConfigurationScope.User);
 		expect(userPlanners).to.have.lengthOf(1);
 		const createdPlanner = userPlanners[0];
@@ -93,7 +95,7 @@ suite('Planner configuration test', () => {
 
 		// THEN
 		expect(workspaceFolderPlanners).to.have.lengthOf(1);
-		expect(allPlanners).to.have.lengthOf(2);
+		expect(allPlanners).to.have.lengthOf(outOfTheBoxPlanners + 1);
 		const createdPlanner = allPlanners[0];
 		expect(createdPlanner).to.not.be.undefined;
 		expect(createdPlanner.scope).to.equal(PlannerConfigurationScope.WorkspaceFolder);
@@ -207,7 +209,7 @@ suite('Planner configuration test', () => {
 		const postSelectedPlanner = plannersConfiguration.getSelectedPlanner(wf);
 
 		expect(workspaceFolderPlanners).to.have.lengthOf(1);
-		expect(allPlanners).to.have.lengthOf(2);
+		expect(allPlanners).to.have.lengthOf(outOfTheBoxPlanners + 1);
 		const actualUpdatedPlanner = workspaceFolderPlanners[0];
 		expect(actualUpdatedPlanner).to.not.be.undefined;
 		expect(actualUpdatedPlanner.path).to.not.be.undefined;
@@ -274,7 +276,7 @@ suite('Planner configuration test', () => {
 		expect(legacyPlanner, "migrated legacy executable should be removed").to.equal('');
 		expect(workspace.getConfiguration(PDDL_PLANNER).get(EXECUTABLE_OPTIONS)).to.equal('', "migrated legacy executable syntax should be removed");
 		const migratedPlanners = plannersConfiguration.getPlanners();
-		expect(migratedPlanners).to.have.lengthOf(2);
+		expect(migratedPlanners).to.have.lengthOf(outOfTheBoxPlanners + 1);
 		const migratedPlanner = migratedPlanners[0];
 		expect(migratedPlanner).to.not.be.undefined;
 		expect(migratedPlanner.scope).to.equal(PlannerConfigurationScope.User);
@@ -296,7 +298,7 @@ suite('Planner configuration test', () => {
 		expect(workspace.getConfiguration(PDDL_PLANNER).get(EXECUTABLE_OR_SERVICE)).to.equal('', "migrated legacy executable should be removed");
 		expect(workspace.getConfiguration(PDDL_PLANNER).get(EXECUTABLE_OPTIONS)).to.equal('', "migrated legacy executable syntax should be removed");
 		const migratedPlanners = plannersConfiguration.getPlanners();
-		expect(migratedPlanners).to.have.lengthOf(2);
+		expect(migratedPlanners).to.have.lengthOf(outOfTheBoxPlanners + 1);
 		const migratedPlanner = migratedPlanners[0];
 		expect(migratedPlanner).to.not.be.undefined;
 		expect(migratedPlanner.scope).to.equal(PlannerConfigurationScope.User);


### PR DESCRIPTION
### Planutil server support

Install the [planutils](https://pypi.org/project/planutils/) package if you are on a Linux-like envoirnment or can activate the WSL Windows Subsystem for Linux (as mentioned below). You will have a whole bunch  of planners suddenly at your fingertips.

#### Installing `planutils`

If you are on a linux-based environment, or use WSL on Windows, follow these steps to install [`planutils`](https://pypi.org/project/planutils/) there.

If you can run `docker` on your system, [follow the instructions for Docker](https://pypi.org/project/planutils/).

If you can just use Python, here is what you need to do:

```bash
pip install planutils
planutils setup
planutils activate
```

if `planutils` does not seem to be available, refresh the bash context to read in the updated `path`.

Instally any planner you want, e.g. ...

```bash
planutils install lama
```

Start the service. (replicating what [Docker would do for you automatically](https://github.com/AI-Planning/planutils/blob/main/environments/server/Dockerfile)):

```bash
pip install flask

planutils server --port 5555
```

Add a planner of the type _Planutils server_ and keep the address as suggested `http://localhost:5555/package`. Plan. Enjoy.
