### PR TITLE
Remove incorrect parameter of splitlines in transform_jinja2

### DIFF
--- a/scripts/transform_jinja2.py
+++ b/scripts/transform_jinja2.py
@@ -32,7 +32,7 @@ def map_filter(value: any, attribute_name: str, default=None) -> any:
 
 def sanitize_line_ends(value: str) -> str:
     """ sanitize values to be printed as single line comments """
-    return ", ".join(value.splitlines(value))
+    return ", ".join(value.splitlines())
 
 def main(args):
     """ Transforms the problem file streamed in through the standard input using JSON the data file passed via command-line argument. """


### PR DESCRIPTION
I was getting some issues with the jinja2 transformer. Digging into this, it turned out that there was an apparent typo in the argument of `value.splitlines()` (takes a boolean as arg).

Removing it, fixes my test case, and also fixes the [example in your samples](https://github.com/jan-dolejsi/vscode-pddl-samples/blob/master/ScriptedTemplating/.ptest.json#L7). So, I wondered if this might be a fix that would be useful to others as well.

Also just wanted to leave a note that many thanks for this project and all your effort into this fantastic project and extension 💙  