### PR TITLE
Planning-as-a-service URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -682,8 +682,8 @@
             },
             {
               "kind": "PLANNING_AS_A_SERVICE_PREVIEW",
-              "url": "http://45.113.232.43:5001/package",
-              "title": "Planning as a service (preview)",
+              "url": "https://paas-uom.org:5001/package",
+              "title": "Planning as a service (paas-uom.org:5001)",
               "canConfigure": false
             }
           ],

--- a/src/configuration/plannerConfigurations.ts
+++ b/src/configuration/plannerConfigurations.ts
@@ -133,7 +133,7 @@ export class PlanutilsServerProvider extends LongRunningPlannerProvider {
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     showHelp(_output: OutputAdaptor): void {
-        throw new Error("Method not implemented."); // possibly show a page like http://45.113.232.43/docs/lama
+        throw new Error("Method not implemented."); // possibly show a page like https://paas-uom.org/docs/lama
     }
 
     /** Custom `Planner` implementation. */
@@ -187,7 +187,7 @@ export class PlanningAsAServiceProvider extends LongRunningPlannerProvider {
     }
 
     async configurePlanner(previousConfiguration?: planner.PlannerConfiguration): Promise<planner.PlannerConfiguration | undefined> {
-        const existingValue = previousConfiguration?.url ?? "http://45.113.232.43/package";
+        const existingValue = previousConfiguration?.url ?? "https://paas-uom.org/package";
 
         const existingUri = Uri.parse(existingValue);
         const indexOf = existingValue.indexOf(existingUri.authority);
@@ -219,7 +219,7 @@ export class PlanningAsAServiceProvider extends LongRunningPlannerProvider {
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     showHelp(_output: OutputAdaptor): void {
-        throw new Error("Method not implemented."); // possibly show a page like http://45.113.232.43/docs/lama
+        throw new Error("Method not implemented."); // possibly show a page like https://paas-uom.org/docs/lama
     }
 
     /** Custom `Planner` implementation. */

--- a/src/planning/PackagedPlannerSelector.ts
+++ b/src/planning/PackagedPlannerSelector.ts
@@ -25,13 +25,9 @@ export class PackagedPlannerSelector extends PackagedPlanners {
     async select(): Promise<SelectedEndpoint | undefined> {
         const manifests = await this.getManifests();
         const plannerItems: PackageQuickPickItem[] = [];
-        for (const key in manifests) {
-            if (Object.prototype.hasOwnProperty.call(manifests, key)) {
-                const manifest = manifests[key];
-                manifest.package_name = key;
-                const item = this.toManifestQuickPickItem(manifest);
-                plannerItems.push(item);
-            }
+        for (const manifest of manifests) {
+            const item = this.toManifestQuickPickItem(manifest);
+            plannerItems.push(item);
         }
         const selectedOption = await window.showQuickPick(plannerItems, {
             matchOnDescription: true, matchOnDetail: true, placeHolder: 'Select a planner...'


### PR DESCRIPTION
Taking the hint from #163 thanks to @nirlipo

Also fixing the interpretation of the manifests payload. It is now a list rather than a map/object.