### PR TITLE
planning-as-a-service as default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # PDDL support - What's new?
 
+## 2.28.0
+
+Updated the [solver.planning.domains](https://solver.planning.domains) default planner to the new Planning-as-a-service api.
+
 ## 2.27.2
 
 3rd party library updates.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pddl",
-  "version": "2.27.2",
+  "version": "2.28.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pddl",
-      "version": "2.27.2",
+      "version": "2.28.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Planning Domain Description Language support",
   "author": "Jan Dolejsi",
   "license": "MIT",
-  "version": "2.27.2",
+  "version": "2.28.0",
   "publisher": "jan-dolejsi",
   "engines": {
     "vscode": "^1.69.0",
@@ -660,7 +660,7 @@
           "scope": "resource",
           "type": "string",
           "description": "Title field of a planner from the `pddl.planners` setting.",
-          "default": "https://solver.planning.domains/solve"
+          "default": "https://solver.planning.domains:5001/package"
         },
         "pddl.showPlannerInStatusBar": {
           "scope": "application",
@@ -675,15 +675,9 @@
           "markdownDescription": "The PDDL Extension can work with multiple **PDDL Planners**. It has a notion of planner _kind_. The _kind_s are defined by the PDDL Extension, or by other extensions injecting in their _Planner Providers_. For more information, see [Configuring the PDDL planner](https://github.com/jan-dolejsi/vscode-pddl/wiki/Configuring-the-PDDL-planner) wiki page.",
           "default": [
             {
-              "kind": "SERVICE_SYNC",
-              "url": "https://solver.planning.domains/solve",
-              "title": "https://solver.planning.domains/solve",
-              "canConfigure": false
-            },
-            {
               "kind": "PLANNING_AS_A_SERVICE_PREVIEW",
-              "url": "https://paas-uom.org:5001/package",
-              "title": "Planning as a service (paas-uom.org:5001)",
+              "url": "https://solver.planning.domains:5001/package",
+              "title": "Planning as a service (solver.planning.domains)",
               "canConfigure": false
             }
           ],
@@ -732,7 +726,7 @@
               "url": {
                 "type": "string",
                 "format": "uri",
-                "description": "URL of the service e.g. https://solver.planning.domains/solve."
+                "description": "URL of the service e.g. https://solver.planning.domains:5001/package."
               },
               "searchDebuggerSupport": {
                 "type": "string",

--- a/src/configuration/plannerConfigurations.ts
+++ b/src/configuration/plannerConfigurations.ts
@@ -97,7 +97,7 @@ export class PlanutilsServerProvider extends LongRunningPlannerProvider {
         return new planner.PlannerKind('planutils_server');
     }
     getNewPlannerLabel(): string {
-        return "$(package) Planutils server (preview) URL...";
+        return "$(package) Planutils server URL...";
     }
 
     async configurePlanner(previousConfiguration?: planner.PlannerConfiguration): Promise<planner.PlannerConfiguration | undefined> {
@@ -180,14 +180,14 @@ export class PlanutilsServerProvider extends LongRunningPlannerProvider {
 
 export class PlanningAsAServiceProvider extends LongRunningPlannerProvider {
     get kind(): planner.PlannerKind {
-        return planner.WellKnownPlannerKind.PLANNING_AS_A_SERVICE_PREVIEW;
+        return planner.WellKnownPlannerKind.PLANNING_AS_A_SERVICE;
     }
     getNewPlannerLabel(): string {
-        return "$(package) Planning-as-a-service (preview) URL...";
+        return "$(package) Planning-as-a-service URL...";
     }
 
     async configurePlanner(previousConfiguration?: planner.PlannerConfiguration): Promise<planner.PlannerConfiguration | undefined> {
-        const existingValue = previousConfiguration?.url ?? "https://paas-uom.org/package";
+        const existingValue = previousConfiguration?.url ?? "https://your-planning-as-a-service:5001/package";
 
         const existingUri = Uri.parse(existingValue);
         const indexOf = existingValue.indexOf(existingUri.authority);
@@ -264,6 +264,13 @@ export class PlanningAsAServiceProvider extends LongRunningPlannerProvider {
     }
 }
 
+/** To support user configurations created using the 'preview' planner configuration. */
+export class PreviewPlanningAsAServiceProvider extends PlanningAsAServiceProvider {
+    get kind(): planner.PlannerKind {
+        return planner.WellKnownPlannerKind.PLANNING_AS_A_SERVICE_PREVIEW;
+    }
+}
+
 export class SolveServicePlannerProvider extends LongRunningPlannerProvider {
     get kind(): planner.PlannerKind {
         return planner.WellKnownPlannerKind.SERVICE_SYNC;
@@ -273,7 +280,7 @@ export class SolveServicePlannerProvider extends LongRunningPlannerProvider {
     }
 
     async configurePlanner(previousConfiguration?: planner.PlannerConfiguration): Promise<planner.PlannerConfiguration | undefined> {
-        const existingValue = previousConfiguration?.url ?? "https://solver.planning.domains/solve";
+        const existingValue = previousConfiguration?.url ?? "https://your-server/solve";
 
         const existingUri = Uri.parse(existingValue);
         const indexOf = existingValue.indexOf(existingUri.authority);

--- a/src/test/suite/PlannerConfiguration.test.ts
+++ b/src/test/suite/PlannerConfiguration.test.ts
@@ -30,7 +30,7 @@ suite('Planner configuration test', () => {
 		await clearConfiguration();
 	});
 
-	const outOfTheBoxPlanners = 2;
+	const outOfTheBoxPlanners = 1;
 
 	test('Default planners are returned in blank configuration', () => {
 		const wf = assertDefined(workspace.workspaceFolders, "workspace folders")[0];
@@ -43,7 +43,7 @@ suite('Planner configuration test', () => {
 		const defaultPlanner = planners[0];
 		expect(defaultPlanner).to.not.be.undefined;
 		expect(defaultPlanner.scope).to.equal(PlannerConfigurationScope.Default);
-		expect(defaultPlanner.configuration.url).to.equal('https://solver.planning.domains/solve');
+		expect(defaultPlanner.configuration.url).to.equal('https://solver.planning.domains:5001/package');
 	});
 
 	test('Creates a user-level planner', async () => {
@@ -303,7 +303,7 @@ suite('Planner configuration test', () => {
 		expect(migratedPlanner).to.not.be.undefined;
 		expect(migratedPlanner.scope).to.equal(PlannerConfigurationScope.User);
 		expect(migratedPlanner.configuration.url).to.equal(executable);
-		expect(migratedPlanner.configuration.title).to.equal(executable + ' #2');
+		expect(migratedPlanner.configuration.title).to.equal(executable);
 	});
 
 


### PR DESCRIPTION
Fixes issue https://github.com/jan-dolejsi/vscode-pddl/issues/182 

Planning-as-a-service hosted at the [solver.planning.domains](https://solver.planning.domains) is now the default planner.